### PR TITLE
fix: render pool page when pool missing from graphDB

### DIFF
--- a/src/app/(main)/pools/[address]/pool-client-page.tsx
+++ b/src/app/(main)/pools/[address]/pool-client-page.tsx
@@ -38,9 +38,13 @@ export function PoolClientPage() {
         pool_address: pool_address,
         banner_url: url,
       });
-      utils.pool.get.setData(pool_address, (old) =>
-        old ? { ...old, banner_url: url } : old
-      );
+      if (metadata) {
+        utils.pool.get.setData(pool_address, (old) =>
+          old ? { ...old, banner_url: url } : old
+        );
+      } else {
+        await utils.pool.get.invalidate(pool_address);
+      }
       toast.success("Banner updated");
     } catch (error) {
       console.error(error);
@@ -192,8 +196,8 @@ export function PoolClientPage() {
 
       {/* Modern Tabs Section */}
       <div className="mt-12">
-        {metadata && pool ? (
-          <PoolTabs pool={pool} isOwner={isOwner} metadata={metadata} />
+        {!isMetadataLoading && pool ? (
+          <PoolTabs pool={pool} isOwner={isOwner} metadata={metadata ?? null} />
         ) : (
           <div className="space-y-8">
             <div className="border-b border-gray-200 bg-white rounded-2xl overflow-hidden">

--- a/src/app/(main)/pools/[address]/pool-client-page.tsx
+++ b/src/app/(main)/pools/[address]/pool-client-page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useParams } from "next/navigation";
 import { toast } from "sonner";
 import { getAddress } from "viem";
+import Link from "next/link";
 import Address from "~/components/address";
 import { EditableImageOverlay } from "~/components/editable-image-overlay";
 import { ContentContainer } from "~/components/layout/content-container";
@@ -22,7 +23,7 @@ import { PoolTabs } from "./pool-tabs";
 export function PoolClientPage() {
   const { address } = useParams<{ address: string }>();
   const pool_address = getAddress(address);
-  const { data: pool } = useSwapPool(pool_address);
+  const { data: pool, isError: isPoolError, isLoading: isPoolLoading } = useSwapPool(pool_address);
   const { data: metadata, isLoading: isMetadataLoading } = trpc.pool.get.useQuery(pool_address);
 
   const isOwner = useIsContractOwner(pool_address);
@@ -31,6 +32,22 @@ export function PoolClientPage() {
   const updatePool = trpc.pool.update.useMutation();
 
   const canEdit = hasPermission(auth?.user, isOwner, "Pools", "UPDATE");
+
+  if (isPoolError || (!isPoolLoading && !pool)) {
+    return (
+      <ContentContainer title="Pool Not Found" className="bg-transparent">
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Pool Not Found</h1>
+          <p className="text-gray-500 mb-6">
+            The address <code className="text-sm bg-gray-100 px-2 py-1 rounded">{pool_address}</code> is not a valid swap pool.
+          </p>
+          <Link href="/pools" className="text-primary underline underline-offset-4 hover:text-primary/80">
+            Browse all pools
+          </Link>
+        </div>
+      </ContentContainer>
+    );
+  }
 
   const handleBannerSave = async (url: string) => {
     try {

--- a/src/app/(main)/pools/[address]/pool-tabs.tsx
+++ b/src/app/(main)/pools/[address]/pool-tabs.tsx
@@ -25,7 +25,7 @@ import { PoolAnalyticsWrapper } from "./pool-analytics-client";
 interface PoolTabsProps {
   pool: SwapPool;
   isOwner?: boolean;
-  metadata: RouterOutputs["pool"]["get"];
+  metadata: RouterOutputs["pool"]["get"] | null;
 }
 
 export function PoolTabs({ pool, isOwner, metadata }: PoolTabsProps) {
@@ -118,15 +118,24 @@ export function PoolTabs({ pool, isOwner, metadata }: PoolTabsProps) {
           <h2 className="text-2xl font-semibold mb-6 text-gray-900">
             Edit Pool
           </h2>
-          {metadata && (
-            <UpdatePoolForm
-              initialValues={{
-                ...metadata,
-                pool_name: metadata.pool_name ?? pool.name,
-                tags: metadata.tags ?? [],
-              }}
-            />
-          )}
+          <UpdatePoolForm
+            initialValues={
+              metadata
+                ? {
+                    ...metadata,
+                    pool_name: metadata.pool_name ?? pool.name,
+                    tags: metadata.tags ?? [],
+                  }
+                : {
+                    pool_address: pool.address,
+                    pool_name: pool.name ?? "",
+                    swap_pool_description: "",
+                    banner_url: null,
+                    tags: [],
+                    unit_of_account: "USD",
+                  }
+            }
+          />
         </>
       ),
     },

--- a/src/server/api/routers/pool.ts
+++ b/src/server/api/routers/pool.ts
@@ -284,6 +284,13 @@ export const poolRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const pool_address = getAddress(input.pool_address);
+      const isInIndex = await PoolIndex.has(pool_address);
+      if (!isInIndex) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Pool not found in the pool index",
+        });
+      }
       const isContractOwner = await getIsContractOwner(
         publicClient,
         ctx.session.address,


### PR DESCRIPTION
## Summary
- Pool pages showed infinite loading skeletons when a pool existed in the SWAP_POOL_INDEX contract but had no entry in graphDB (e.g. `0x2a05cf3E23595bf0a2BE0b2E30Da9B0647cE7C3f`)
- Changed the render condition from checking metadata truthiness to checking `isMetadataLoading`, so the page renders with contract data even when graphDB returns null
- The Settings tab now provides default values from the contract when metadata is null, enabling the UpdatePoolForm to upsert a new graphDB entry and the remove button to be accessible

## Test plan
- [ ] Visit a pool page for a pool that exists in the index contract but not in graphDB — tabs and content should render instead of infinite skeletons
- [ ] Verify the Settings tab shows the update form with contract defaults and allows saving (creates graphDB entry)
- [ ] Verify the remove button is accessible for authorized users (SUPER_ADMIN or contract owner)
- [ ] Verify existing pools with graphDB entries still render correctly with their metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)