### PR TITLE
fix: remove hardcoded gas fee cap to unblock transactions

### DIFF
--- a/src/components/dialogs/receive-dialog.tsx
+++ b/src/components/dialogs/receive-dialog.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, CircleCheck, Send, Smartphone } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { erc20Abi, parseGwei, parseUnits } from "viem";
+import { erc20Abi, parseUnits } from "viem";
 import { useAccount, useSimulateContract, useWriteContract } from "wagmi";
 import { z } from "zod";
 
@@ -350,8 +350,6 @@ const RequestForm = (props: {
     },
     account: walletResult?.address,
     gas: 350_000n,
-    maxFeePerGas: parseGwei("27"),
-    maxPriorityFeePerGas: 5n,
   });
 
   const { data: hash, writeContractAsync, isPending } = useWriteContract();

--- a/src/components/dialogs/send-dialog.tsx
+++ b/src/components/dialogs/send-dialog.tsx
@@ -9,7 +9,7 @@ import * as z from "zod";
 import { type WriteContractErrorType } from "@wagmi/core";
 import React from "react";
 import { toast } from "sonner";
-import { erc20Abi, isAddress, parseGwei, parseUnits } from "viem";
+import { erc20Abi, isAddress, parseUnits } from "viem";
 import { useAccount, useSimulateContract, useWriteContract } from "wagmi";
 import { ResponsiveModal } from "~/components/responsive-modal";
 import { useBalance } from "~/contracts/react";
@@ -111,8 +111,6 @@ export const SendForm = (props: {
       ),
     },
     gas: 350_000n,
-    maxFeePerGas: parseGwei("27"),
-    maxPriorityFeePerGas: 5n,
   });
 
   const { data: hash, writeContractAsync, isPending } = useWriteContract();

--- a/src/contracts/erc20-demurrage-token/index.ts
+++ b/src/contracts/erc20-demurrage-token/index.ts
@@ -1,5 +1,4 @@
 import {
-  parseGwei,
   parseUnits,
   type Chain,
   type PublicClient,
@@ -63,8 +62,6 @@ export class DMRToken<t extends Transport, c extends Chain> {
       bytecode: bytecode,
       args: contract_args,
       gas: 10_000_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,
@@ -104,8 +101,6 @@ export class DMRToken<t extends Transport, c extends Chain> {
       ...this.contract,
       functionName: "mintTo",
       gas: 350_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
       args: [to, parseUnits(amount.toString(), Number(decimals))],
     });
     const receipt = await this.publicClient.waitForTransactionReceipt({

--- a/src/contracts/erc20-giftable-token/index.ts
+++ b/src/contracts/erc20-giftable-token/index.ts
@@ -1,5 +1,4 @@
 import {
-  parseGwei,
   parseUnits,
   type Chain,
   type PublicClient,
@@ -52,8 +51,6 @@ export class GiftableToken<t extends Transport, c extends Chain> {
       bytecode: bytecode,
       args: contract_args,
       gas: 4_000_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,
@@ -95,8 +92,6 @@ export class GiftableToken<t extends Transport, c extends Chain> {
       ...this.contract,
       functionName: "mintTo",
       gas: 350_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
       args: [to, parseUnits(amount.toString(), Number(decimals))],
     });
     const receipt = await this.publicClient.waitForTransactionReceipt({

--- a/src/contracts/erc20-token-index/index.ts
+++ b/src/contracts/erc20-token-index/index.ts
@@ -1,7 +1,6 @@
 import {
   type Chain,
   hexToNumber,
-  parseGwei,
   type PublicClient,
   toHex,
   type Transport,
@@ -39,8 +38,6 @@ export class TokenIndex<t extends Transport, c extends Chain> {
       abi: tokenIndexABI,
       bytecode: tokenIndexBytecode,
       gas: 2_500_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,

--- a/src/contracts/limiter/index.ts
+++ b/src/contracts/limiter/index.ts
@@ -1,5 +1,4 @@
 import {
-  parseGwei,
   type Address,
   type Chain,
   type PublicClient,
@@ -26,8 +25,6 @@ export class Limiter<t extends Transport, c extends Chain> {
       abi: limiterAbi,
       bytecode: limiterBytecode,
       gas: 1_000_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,

--- a/src/contracts/price-index-quote/index.ts
+++ b/src/contracts/price-index-quote/index.ts
@@ -1,5 +1,4 @@
 import {
-  parseGwei,
   type Address,
   type Chain,
   type PublicClient,
@@ -28,8 +27,6 @@ export class PriceIndexQuote<t extends Transport, c extends Chain> {
       abi: priceIndexQuoteAbi,
       bytecode: priceIndexBytecode,
       gas: 2_500_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,

--- a/src/contracts/swap-pool/index.ts
+++ b/src/contracts/swap-pool/index.ts
@@ -1,7 +1,6 @@
 import {
   type Chain,
   getAddress,
-  parseGwei,
   type PublicClient,
   type Transport,
 } from "viem";
@@ -49,8 +48,6 @@ export class SwapPoolContract<t extends Transport, c extends Chain> {
       bytecode: swapPoolBytecode,
       args: [name, symbol, decimals, tokenRegistryAddress, limiterAddress],
       gas: 4_000_000n,
-      maxFeePerGas: parseGwei("27"),
-      maxPriorityFeePerGas: 5n,
     });
     const receipt = await publicClient.waitForTransactionReceipt({
       hash,


### PR DESCRIPTION
## Summary
- Removed hardcoded `maxFeePerGas` (27 gwei) and `maxPriorityFeePerGas` from all 10 call sites across 8 files
- Celo's block base fee has risen above 27 gwei, causing all transactions to fail with "fee cap cannot be lower than block base fee"
- Viem/wagmi will now auto-estimate gas fees from the network, preventing recurrence

## Test plan
- [ ] Verify sending vouchers works in send dialog
- [ ] Verify receiving vouchers works in receive dialog
- [ ] Verify contract deployments (demurrage, giftable, swap pool, token index, limiter, price index) succeed
- [ ] Confirm TypeScript type check passes (`pnpm check-types`)