### PR TITLE
feat(marketplace): replace landing page with location-aware marketplace

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(main)/about/page.tsx
+++ b/src/app/(main)/about/page.tsx
@@ -1,0 +1,49 @@
+import { type Metadata } from "next";
+import { CallToAction } from "~/components/landing/CallToAction";
+import { CommunityImpact } from "~/components/landing/CommunityImpact";
+import { Features } from "~/components/landing/Features";
+import { Footer } from "~/components/landing/Footer";
+import { Hero } from "~/components/landing/Hero";
+import { HowItWorks } from "~/components/landing/HowItWorks";
+import { Partners } from "~/components/landing/Partners";
+import { RoleSeparator } from "~/components/landing/RoleSeparator";
+import { Seeders } from "~/components/landing/Seeders";
+import { ServiceProviders } from "~/components/landing/ServiceProviders";
+import { Stewards } from "~/components/landing/Stewards";
+import { VoucherUsers } from "~/components/landing/VoucherUsers";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Learn about the Sarafu Network and how community asset vouchers work.",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen">
+      <Hero
+        poolCount={141}
+        memberCount={3540}
+        transactionCount={271144}
+        vouchersCount={752}
+      />
+      <HowItWorks />
+      {/* <MobileAccessibility /> - Hidden for now but kept for potential future use */}
+      {/* User Group Sections */}
+      <div>
+        <Stewards />
+        <RoleSeparator />
+        <ServiceProviders />
+        <RoleSeparator />
+        <VoucherUsers />
+        <RoleSeparator />
+        <Seeders />
+      </div>
+      <CommunityImpact />
+      <Features />
+      <Partners />
+      <CallToAction />
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/(main)/map/page.tsx
+++ b/src/app/(main)/map/page.tsx
@@ -4,6 +4,7 @@ import { getAddress } from "viem";
 import { DataMap, type MapDataItemPoint } from "~/components/map/data-map";
 import { caller } from "~/server/api/routers/_app";
 import { cacheWithExpiry } from "~/utils/cache/cache";
+import { pointToLatLng } from "~/utils/units/geo";
 
 export const revalidate = 3600; // 1 hour
 
@@ -18,68 +19,50 @@ async function MapPage() {
           limit: 2000,
         }),
       ]);
-    }
+    },
   );
-
-  const voucherGeoMap = new Map<
-    `0x${string}`,
-    { lat: number; lon: number; name?: string }
-  >();
-  vouchersWithGeo.forEach((v) => {
-    if (v.geo?.x && v.geo?.y) {
-      const address = getAddress(v.voucher_address);
-      voucherGeoMap.set(address, {
-        lat: v.geo.x,
-        lon: v.geo.y,
-        name: v.voucher_name,
-      });
-    }
-  });
 
   const mapPointsData: MapDataItemPoint[] = [];
 
-  vouchersWithGeo.forEach((v) => {
+  for (const v of vouchersWithGeo) {
+    const latLng = pointToLatLng(v.geo);
+    if (!latLng) continue;
     const address = getAddress(v.voucher_address);
-    if (v.geo?.x && v.geo?.y) {
-      mapPointsData.push({
-        type: "voucher",
-        id: `voucher-${address}`,
-        href: `/vouchers/${address}`,
-        latitude: v.geo.x,
-        longitude: v.geo.y,
-        data: {
-          voucher_address: address,
-          title: v.voucher_name ?? "Unnamed Voucher",
-          image: v.banner_url ?? "",
-          description: v.voucher_description,
-        },
-      });
-    }
-  });
+    mapPointsData.push({
+      type: "voucher",
+      id: `voucher-${address}`,
+      href: `/vouchers/${address}`,
+      latitude: latLng.latitude,
+      longitude: latLng.longitude,
+      data: {
+        voucher_address: address,
+        title: v.voucher_name ?? "Unnamed Voucher",
+        image: v.banner_url ?? "",
+        description: v.voucher_description,
+      },
+    });
+  }
 
   const reports = reportsResult?.items;
   if (reports) {
-    mapPointsData.push(
-      ...reports
-        .filter((r) => r.location?.x && r.location?.y)
-        .map(
-          (r) =>
-            ({
-              type: "report",
-              href: `/reports/${r.id}`,
-              id: `report-${r.id}`,
-              latitude: r.location!.x,
-              longitude: r.location!.y,
-              data: {
-                id: r.id,
-                title: r.title ?? "Untitled Report",
-                description: r.description ?? "",
-                image: r.image_url ?? "",
-                tags: r.tags ?? [],
-              },
-            } as const)
-        )
-    );
+    for (const r of reports) {
+      const latLng = pointToLatLng(r.location);
+      if (!latLng) continue;
+      mapPointsData.push({
+        type: "report",
+        href: `/reports/${r.id}`,
+        id: `report-${r.id}`,
+        latitude: latLng.latitude,
+        longitude: latLng.longitude,
+        data: {
+          id: r.id,
+          title: r.title ?? "Untitled Report",
+          description: r.description ?? "",
+          image: r.image_url ?? "",
+          tags: r.tags ?? [],
+        },
+      });
+    }
   }
 
   return (

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,42 +1,35 @@
-import { CallToAction } from "~/components/landing/CallToAction";
-import { CommunityImpact } from "~/components/landing/CommunityImpact";
-import { Features } from "~/components/landing/Features";
-import { Footer } from "~/components/landing/Footer";
-import { Hero } from "~/components/landing/Hero";
-import { HowItWorks } from "~/components/landing/HowItWorks";
-import { Partners } from "~/components/landing/Partners";
-import { RoleSeparator } from "~/components/landing/RoleSeparator";
-import { Seeders } from "~/components/landing/Seeders";
-import { ServiceProviders } from "~/components/landing/ServiceProviders";
-import { Stewards } from "~/components/landing/Stewards";
-import { VoucherUsers } from "~/components/landing/VoucherUsers";
+import { type Metadata } from "next";
+import Link from "next/link";
+import { ContentContainer } from "~/components/layout/content-container";
+import { MarketplacePage } from "~/components/marketplace/marketplace-page";
 
-export default function LandingPage() {
+export const metadata: Metadata = {
+  title: "Marketplace",
+  description:
+    "Discover pools near you and swap community asset vouchers on the Sarafu Network.",
+  openGraph: {
+    title: "Marketplace",
+    description:
+      "Discover pools near you and swap community asset vouchers on the Sarafu Network.",
+  },
+};
+
+export default function HomePage() {
   return (
-    <div className="min-h-screen">
-      <Hero
-        poolCount={141}
-        memberCount={3540}
-        transactionCount={271144}
-        vouchersCount={752}
-      />
-      <HowItWorks />
-      {/* <MobileAccessibility /> - Hidden for now but kept for potential future use */}
-      {/* User Group Sections */}
-      <div>
-        <Stewards />
-        <RoleSeparator />
-        <ServiceProviders />
-        <RoleSeparator />
-        <VoucherUsers />
-        <RoleSeparator />
-        <Seeders />
+    <ContentContainer title="Marketplace" className="bg-transparent">
+      <div className="flex flex-col gap-2 mt-2 ml-4">
+        <h1 className="flex items-center gap-2 text-4xl sm:text-5xl font-bold">
+          Marketplace
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Explore pools near you.{" "}
+          <Link href="/about" className="underline hover:text-foreground">
+            Learn about the Sarafu Network
+          </Link>
+          .
+        </p>
       </div>
-      <CommunityImpact />
-      <Features />
-      <Partners />
-      <CallToAction />
-      <Footer />
-    </div>
+      <MarketplacePage />
+    </ContentContainer>
   );
 }

--- a/src/components/forms/fields/map-field.tsx
+++ b/src/components/forms/fields/map-field.tsx
@@ -24,6 +24,7 @@ import {
   type GeocodeSuggestion,
 } from "~/lib/geocoder";
 import { cn } from "~/lib/utils";
+import { latLngToPoint, pointToLatLng } from "~/utils/units/geo";
 import { type FilterNamesByValue } from "./type-helper";
 
 const LocationMap = dynamic(() => import("~/components/map/location-map"), {
@@ -141,10 +142,7 @@ export function MapField<F extends UseFormReturn<any>>({
     },
   ) => {
     if (disabled) return;
-    field.onChange({
-      x: p.latitude,
-      y: p.longitude,
-    });
+    field.onChange(latLngToPoint(p));
     if (!locationName) return;
     getLocation(p)
       .then((location) => {
@@ -174,10 +172,12 @@ export function MapField<F extends UseFormReturn<any>>({
       >,
       suggestion: GeocodeSuggestion,
     ) => {
-      field.onChange({
-        x: suggestion.latitude,
-        y: suggestion.longitude,
-      });
+      field.onChange(
+        latLngToPoint({
+          latitude: suggestion.latitude,
+          longitude: suggestion.longitude,
+        }),
+      );
       if (locationName) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -322,17 +322,15 @@ export function MapField<F extends UseFormReturn<any>>({
                 <div className="w-full h-96 max-h-[30vh] rounded-md overflow-clip">
                   <LocationMap
                     disabled={disabled}
-                    onCurrentLocation={(p) =>
-                      handelUpdateLocation(field, p)
-                    }
+                    onCurrentLocation={(p) => handelUpdateLocation(field, p)}
                     showSearchBar={false}
                     value={
-                      field.value
-                        ? {
-                            latitude: field.value.x as number,
-                            longitude: field.value.y as number,
-                          }
-                        : undefined
+                      pointToLatLng(
+                        field.value as
+                          | { x: number; y: number }
+                          | null
+                          | undefined,
+                      ) ?? undefined
                     }
                     onChange={(p) => handelUpdateLocation(field, p)}
                   />

--- a/src/components/marketplace/marketplace-page.tsx
+++ b/src/components/marketplace/marketplace-page.tsx
@@ -57,6 +57,10 @@ type LocationStatus = "idle" | "requesting" | "granted" | "denied";
 
 const STALE_TIME_MS = 60_000;
 const USER_LOCATION_STORAGE_KEY = "sarafu:marketplace:userLocation";
+// Mirrors the geolocation `maximumAge` cap: a position older than this is
+// suspect (the user may have moved). On the next page load we discard it and
+// re-request, so a long-lived tab doesn't silently sort by a stale fix.
+const STORED_LOCATION_MAX_AGE_MS = 5 * 60_000;
 
 type StoredUserLocation = UserLocation & { savedAt: number };
 
@@ -70,6 +74,13 @@ function readStoredLocation(): UserLocation | null {
       typeof parsed.latitude !== "number" ||
       typeof parsed.longitude !== "number"
     ) {
+      return null;
+    }
+    if (
+      typeof parsed.savedAt !== "number" ||
+      Date.now() - parsed.savedAt > STORED_LOCATION_MAX_AGE_MS
+    ) {
+      window.sessionStorage.removeItem(USER_LOCATION_STORAGE_KEY);
       return null;
     }
     return { latitude: parsed.latitude, longitude: parsed.longitude };

--- a/src/components/marketplace/marketplace-page.tsx
+++ b/src/components/marketplace/marketplace-page.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import {
+  LayoutGrid,
+  LayoutList,
+  LocateFixed,
+  MapPin,
+  Search,
+} from "lucide-react";
+import Link from "next/link";
+import {
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { PoolListItem } from "~/components/pools/pool-list-item";
+import {
+  OfferGridCard,
+  OfferGridCardSkeleton,
+} from "~/components/products/offer-grid-card";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { MultiSelect } from "~/components/ui/multi-select";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+import { trpc, type RouterOutputs } from "~/lib/trpc";
+import {
+  distanceKmFromPoint,
+  formatDistanceKm,
+  type LatLng,
+} from "~/utils/units/geo";
+import { truncateByDecimalPlace } from "~/utils/units/number";
+
+type ViewMode = "grid" | "list";
+
+type UserLocation = LatLng;
+
+type LocationStatus = "idle" | "requesting" | "granted" | "denied";
+
+const STALE_TIME_MS = 60_000;
+const USER_LOCATION_STORAGE_KEY = "sarafu:marketplace:userLocation";
+
+type StoredUserLocation = UserLocation & { savedAt: number };
+
+function readStoredLocation(): UserLocation | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(USER_LOCATION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredUserLocation>;
+    if (
+      typeof parsed.latitude !== "number" ||
+      typeof parsed.longitude !== "number"
+    ) {
+      return null;
+    }
+    return { latitude: parsed.latitude, longitude: parsed.longitude };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredLocation(loc: UserLocation) {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: StoredUserLocation = { ...loc, savedAt: Date.now() };
+    window.sessionStorage.setItem(
+      USER_LOCATION_STORAGE_KEY,
+      JSON.stringify(payload),
+    );
+  } catch {
+    // Ignore quota / disabled storage errors.
+  }
+}
+
+const INITIAL_BATCH = 24;
+const NEXT_BATCH = 24;
+
+/**
+ * Progressive rendering for responsive grids. Returns the visible slice and a
+ * sentinel ref to attach at the end of the list — when it scrolls into view,
+ * we reveal another batch. Avoids rendering hundreds of cards eagerly while
+ * keeping the existing CSS grid layout intact.
+ *
+ * `visibleCount` grows monotonically and is clamped to `items.length` at
+ * render time, so filters/sorts that shrink the list don't need a reset and
+ * returning items appear immediately when the filter is cleared.
+ */
+function useProgressiveSlice<T>(items: T[]) {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_BATCH);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const effectiveCount = Math.min(
+    Math.max(visibleCount, INITIAL_BATCH),
+    items.length,
+  );
+  const hasMore = effectiveCount < items.length;
+
+  useEffect(() => {
+    if (!hasMore) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisibleCount((prev) => prev + NEXT_BATCH);
+          }
+        }
+      },
+      { rootMargin: "400px 0px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasMore]);
+
+  return {
+    slice: items.slice(0, effectiveCount),
+    sentinelRef,
+    hasMore,
+  };
+}
+
+function PoolCardSkeleton({ viewMode }: { viewMode: ViewMode }) {
+  if (viewMode === "list") {
+    return (
+      <div className="flex gap-3 py-4 px-4">
+        <Skeleton className="h-12 w-12 rounded-lg" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <Card className="overflow-hidden h-[400px] flex flex-col">
+      <Skeleton className="h-48 w-full" />
+      <CardHeader>
+        <Skeleton className="h-6 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3 mt-2" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function PoolsView({
+  searchTerm,
+  searchTags,
+  viewMode,
+  userLocation,
+}: {
+  searchTerm: string;
+  searchTags: string[];
+  viewMode: ViewMode;
+  userLocation: UserLocation | null;
+}) {
+  const { data: pools, isLoading } = trpc.pool.list.useQuery(
+    {
+      sortBy: "swaps",
+      sortDirection: "desc",
+    },
+    { staleTime: STALE_TIME_MS },
+  );
+
+  const sortedPools = useMemo(() => {
+    if (!pools) return [];
+
+    const withDistance = pools.map((pool) => ({
+      ...pool,
+      distance_km: distanceKmFromPoint(userLocation, pool.geo),
+    }));
+
+    if (userLocation) {
+      return withDistance.sort((a, b) => {
+        if (a.distance_km == null && b.distance_km == null) {
+          return b.swap_count - a.swap_count;
+        }
+        if (a.distance_km == null) return 1;
+        if (b.distance_km == null) return -1;
+        return a.distance_km - b.distance_km;
+      });
+    }
+
+    return withDistance;
+  }, [pools, userLocation]);
+
+  const filteredPools = useMemo(() => {
+    const term = searchTerm.toLowerCase();
+    return sortedPools.filter((pool) => {
+      const matchesSearch =
+        term === "" ||
+        pool.pool_name.toLowerCase().includes(term) ||
+        pool.pool_symbol.toLowerCase().includes(term) ||
+        pool.description.toLowerCase().includes(term);
+      const matchesTags =
+        searchTags.length === 0 ||
+        searchTags.every((tag) => pool.tags.includes(tag));
+      return matchesSearch && matchesTags;
+    });
+  }, [sortedPools, searchTerm, searchTags]);
+
+  if (isLoading) {
+    return (
+      <div
+        className={
+          viewMode === "grid"
+            ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+            : "border rounded-lg divide-y"
+        }
+      >
+        {Array.from({ length: 8 }).map((_, idx) => (
+          <PoolCardSkeleton key={idx} viewMode={viewMode} />
+        ))}
+      </div>
+    );
+  }
+
+  if (filteredPools.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed py-12 px-4 text-center">
+        <p className="text-base sm:text-lg text-muted-foreground">
+          No pools match your search.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PoolGrid pools={filteredPools} viewMode={viewMode} />
+  );
+}
+
+type PoolWithDistance = RouterOutputs["pool"]["list"][number] & {
+  distance_km: number | null;
+};
+
+function PoolGrid({
+  pools,
+  viewMode,
+}: {
+  pools: PoolWithDistance[];
+  viewMode: ViewMode;
+}) {
+  const { slice, sentinelRef, hasMore } = useProgressiveSlice(pools);
+  return (
+    <>
+      <div
+        className={
+          viewMode === "grid"
+            ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+            : "border rounded-lg divide-y"
+        }
+      >
+        {slice.map((pool) => (
+          <PoolListItem
+            key={pool.contract_address}
+            pool={pool}
+            viewMode={viewMode}
+          />
+        ))}
+      </div>
+      {hasMore && <div ref={sentinelRef} className="h-px w-full" />}
+    </>
+  );
+}
+
+function OffersView({
+  searchTerm,
+  searchTags,
+  userLocation,
+}: {
+  searchTerm: string;
+  searchTags: string[];
+  userLocation: UserLocation | null;
+}) {
+  const { data: offers, isLoading } = trpc.products.marketplaceList.useQuery(
+    undefined,
+    { staleTime: STALE_TIME_MS },
+  );
+
+  const sortedOffers = useMemo(() => {
+    if (!offers) return [];
+
+    const withDistance = offers.map((offer) => ({
+      ...offer,
+      distance_km: distanceKmFromPoint(userLocation, offer.voucher_geo),
+    }));
+
+    if (userLocation) {
+      return withDistance.sort((a, b) => {
+        if (a.distance_km == null && b.distance_km == null) return 0;
+        if (a.distance_km == null) return 1;
+        if (b.distance_km == null) return -1;
+        return a.distance_km - b.distance_km;
+      });
+    }
+
+    return withDistance;
+  }, [offers, userLocation]);
+
+  const filteredOffers = useMemo(() => {
+    const term = searchTerm.toLowerCase();
+    return sortedOffers.filter((offer) => {
+      const matchesSearch =
+        term === "" ||
+        offer.commodity_name.toLowerCase().includes(term) ||
+        (offer.commodity_description ?? "").toLowerCase().includes(term) ||
+        offer.voucher_symbol.toLowerCase().includes(term) ||
+        (offer.voucher_name ?? "").toLowerCase().includes(term);
+      const matchesTags =
+        searchTags.length === 0 ||
+        searchTags.every((tag) => offer.tags.includes(tag));
+      return matchesSearch && matchesTags;
+    });
+  }, [sortedOffers, searchTerm, searchTags]);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 sm:gap-4">
+        {Array.from({ length: 10 }).map((_, idx) => (
+          <OfferGridCardSkeleton key={idx} />
+        ))}
+      </div>
+    );
+  }
+
+  if (filteredOffers.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed py-12 px-4 text-center">
+        <p className="text-base sm:text-lg text-muted-foreground">
+          No offers match your search.
+        </p>
+      </div>
+    );
+  }
+
+  return <OfferGrid offers={filteredOffers} />;
+}
+
+type OfferWithDistance = RouterOutputs["products"]["marketplaceList"][number] & {
+  distance_km: number | null;
+};
+
+function OfferGrid({ offers }: { offers: OfferWithDistance[] }) {
+  const { slice, sentinelRef, hasMore } = useProgressiveSlice(offers);
+  return (
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 sm:gap-4">
+        {slice.map((offer) => (
+          <Link key={offer.id} href={`/vouchers/${offer.voucher_address}`}>
+            <OfferGridCard
+              name={offer.commodity_name}
+              imageUrl={offer.image_url || null}
+              locationLabel={offer.location_name || null}
+              priceDisplay={
+                offer.price ? (
+                  <p className="text-xs font-bold tabular-nums whitespace-nowrap mt-0.5">
+                    {truncateByDecimalPlace(offer.price, 2)}{" "}
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {offer.voucher_symbol}
+                    </span>
+                    {offer.unit && (
+                      <span className="text-xs text-muted-foreground">
+                        {" "}
+                        / {offer.unit}
+                      </span>
+                    )}
+                  </p>
+                ) : undefined
+              }
+            >
+              {offer.distance_km != null && (
+                <p className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <MapPin className="h-3 w-3" />
+                  {formatDistanceKm(offer.distance_km)} away
+                </p>
+              )}
+            </OfferGridCard>
+          </Link>
+        ))}
+      </div>
+      {hasMore && <div ref={sentinelRef} className="h-px w-full" />}
+    </>
+  );
+}
+
+export function MarketplacePage() {
+  const [activeTab, setActiveTab] = useState<"pools" | "offers">("pools");
+  const [searchTerm, setSearchTerm] = useState("");
+  const deferredSearchTerm = useDeferredValue(searchTerm);
+  const [searchTags, setSearchTags] = useState<string[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
+  const [locationStatus, setLocationStatus] =
+    useState<LocationStatus>("idle");
+
+  const { data: tags } = trpc.tags.list.useQuery(undefined, {
+    staleTime: STALE_TIME_MS,
+  });
+
+  const requestLocation = () => {
+    if (!navigator.geolocation) {
+      setLocationStatus("denied");
+      return;
+    }
+    setLocationStatus("requesting");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const next = {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        };
+        setUserLocation(next);
+        writeStoredLocation(next);
+        setLocationStatus("granted");
+      },
+      () => {
+        setLocationStatus("denied");
+      },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 300000 },
+    );
+  };
+
+  useEffect(() => {
+    // Hydrate location from sessionStorage post-mount to avoid SSR/CSR mismatch.
+    const stored = readStoredLocation();
+    if (stored) {
+      setUserLocation(stored);
+      setLocationStatus("granted");
+      return;
+    }
+    if (typeof navigator === "undefined" || !navigator.permissions) {
+      return;
+    }
+    navigator.permissions
+      .query({ name: "geolocation" as PermissionName })
+      .then((result) => {
+        if (result.state === "granted") {
+          requestLocation();
+        }
+      })
+      .catch(() => {
+        // Ignore unsupported permission queries
+      });
+    // We intentionally only run on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const tagOptions = useMemo(
+    () => (tags ?? []).map((t) => ({ value: t.tag, label: t.tag })),
+    [tags],
+  );
+
+  const isPoolsTab = activeTab === "pools";
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as "pools" | "offers")}
+      className="mt-4"
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList className="w-full sm:w-auto">
+            <TabsTrigger value="pools" className="flex-1 sm:flex-none">
+              Pools
+            </TabsTrigger>
+            <TabsTrigger value="offers" className="flex-1 sm:flex-none">
+              Offers
+            </TabsTrigger>
+          </TabsList>
+
+          <div className="relative w-full sm:max-w-sm">
+            <Input
+              type="text"
+              placeholder={isPoolsTab ? "Search pools..." : "Search offers..."}
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10 pr-4 py-2 w-full"
+            />
+            <Search
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+              size={18}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant={locationStatus === "granted" ? "default" : "outline"}
+            size="sm"
+            onClick={requestLocation}
+            disabled={locationStatus === "requesting"}
+            className="gap-1.5"
+            title={
+              locationStatus === "granted"
+                ? "Showing items near you — tap to refresh"
+                : "Use my location to sort by distance"
+            }
+          >
+            <LocateFixed className="h-4 w-4" />
+            {locationStatus === "requesting"
+              ? "Locating…"
+              : locationStatus === "granted"
+                ? "Near you"
+                : locationStatus === "denied"
+                  ? "Location off"
+                  : "Near me"}
+          </Button>
+
+          <div className="min-w-[10rem] flex-1 sm:flex-none sm:w-64">
+            <MultiSelect
+              options={tagOptions}
+              selected={searchTags}
+              onChange={setSearchTags}
+              placeholder="Filter by tags"
+            />
+          </div>
+
+          {isPoolsTab && (
+            <ToggleGroup
+              type="single"
+              value={viewMode}
+              onValueChange={(value: ViewMode) => value && setViewMode(value)}
+              className="ml-auto sm:ml-0"
+            >
+              <ToggleGroupItem value="grid" aria-label="Grid view">
+                <LayoutGrid className="h-4 w-4" />
+              </ToggleGroupItem>
+              <ToggleGroupItem value="list" aria-label="List view">
+                <LayoutList className="h-4 w-4" />
+              </ToggleGroupItem>
+            </ToggleGroup>
+          )}
+        </div>
+      </div>
+
+      <TabsContent value="pools" className="mt-6">
+        <PoolsView
+          searchTerm={deferredSearchTerm}
+          searchTags={searchTags}
+          viewMode={viewMode}
+          userLocation={userLocation}
+        />
+      </TabsContent>
+
+      <TabsContent value="offers" className="mt-6">
+        <OffersView
+          searchTerm={deferredSearchTerm}
+          searchTags={searchTags}
+          userLocation={userLocation}
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/components/marketplace/marketplace-page.tsx
+++ b/src/components/marketplace/marketplace-page.tsx
@@ -259,11 +259,12 @@ function PoolGrid({
             : "border rounded-lg divide-y"
         }
       >
-        {slice.map((pool) => (
+        {slice.map((pool, index) => (
           <PoolListItem
             key={pool.contract_address}
             pool={pool}
             viewMode={viewMode}
+            priority={index === 0}
           />
         ))}
       </div>

--- a/src/components/marketplace/marketplace-page.tsx
+++ b/src/components/marketplace/marketplace-page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+  ArrowDownAZ,
+  Activity,
   LayoutGrid,
   LayoutList,
   LocateFixed,
@@ -24,6 +26,13 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { MultiSelect } from "~/components/ui/multi-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
@@ -33,9 +42,14 @@ import {
   formatDistanceKm,
   type LatLng,
 } from "~/utils/units/geo";
-import { truncateByDecimalPlace } from "~/utils/units/number";
+import {
+  formatCurrencyValue,
+  truncateByDecimalPlace,
+} from "~/utils/units/number";
 
 type ViewMode = "grid" | "list";
+
+type SortMode = "auto" | "swaps" | "name";
 
 type UserLocation = LatLng;
 
@@ -156,16 +170,20 @@ function PoolsView({
   searchTags,
   viewMode,
   userLocation,
+  sortMode,
+  onResultCountChange,
 }: {
   searchTerm: string;
   searchTags: string[];
   viewMode: ViewMode;
   userLocation: UserLocation | null;
+  sortMode: SortMode;
+  onResultCountChange: (count: number | null) => void;
 }) {
   const { data: pools, isLoading } = trpc.pool.list.useQuery(
     {
-      sortBy: "swaps",
-      sortDirection: "desc",
+      sortBy: sortMode === "name" ? "name" : "swaps",
+      sortDirection: sortMode === "name" ? "asc" : "desc",
     },
     { staleTime: STALE_TIME_MS },
   );
@@ -178,7 +196,7 @@ function PoolsView({
       distance_km: distanceKmFromPoint(userLocation, pool.geo),
     }));
 
-    if (userLocation) {
+    if (sortMode === "auto" && userLocation) {
       return withDistance.sort((a, b) => {
         if (a.distance_km == null && b.distance_km == null) {
           return b.swap_count - a.swap_count;
@@ -190,7 +208,7 @@ function PoolsView({
     }
 
     return withDistance;
-  }, [pools, userLocation]);
+  }, [pools, userLocation, sortMode]);
 
   const filteredPools = useMemo(() => {
     const term = searchTerm.toLowerCase();
@@ -206,6 +224,14 @@ function PoolsView({
       return matchesSearch && matchesTags;
     });
   }, [sortedPools, searchTerm, searchTags]);
+
+  useEffect(() => {
+    if (isLoading) {
+      onResultCountChange(null);
+    } else {
+      onResultCountChange(filteredPools.length);
+    }
+  }, [isLoading, filteredPools.length, onResultCountChange]);
 
   if (isLoading) {
     return (
@@ -233,9 +259,32 @@ function PoolsView({
     );
   }
 
-  return (
-    <PoolGrid pools={filteredPools} viewMode={viewMode} />
-  );
+  // Group into "Near you" / "Other pools" only when distance-aware sorting is in
+  // effect AND both groups are non-empty — otherwise a header would just add noise.
+  const useGrouping = sortMode === "auto" && userLocation != null;
+  if (useGrouping) {
+    const nearPools = filteredPools.filter((p) => p.distance_km != null);
+    const otherPools = filteredPools.filter((p) => p.distance_km == null);
+    if (nearPools.length > 0 && otherPools.length > 0) {
+      return (
+        <div className="flex flex-col gap-8">
+          <PoolGrid
+            pools={nearPools}
+            viewMode={viewMode}
+            header={`Near you (${nearPools.length.toLocaleString()})`}
+          />
+          <PoolGrid
+            pools={otherPools}
+            viewMode={viewMode}
+            header={`Other pools (${otherPools.length.toLocaleString()})`}
+            headerHint="No location data — sorted by activity"
+          />
+        </div>
+      );
+    }
+  }
+
+  return <PoolGrid pools={filteredPools} viewMode={viewMode} />;
 }
 
 type PoolWithDistance = RouterOutputs["pool"]["list"][number] & {
@@ -245,13 +294,25 @@ type PoolWithDistance = RouterOutputs["pool"]["list"][number] & {
 function PoolGrid({
   pools,
   viewMode,
+  header,
+  headerHint,
 }: {
   pools: PoolWithDistance[];
   viewMode: ViewMode;
+  header?: string;
+  headerHint?: string;
 }) {
   const { slice, sentinelRef, hasMore } = useProgressiveSlice(pools);
   return (
-    <>
+    <section>
+      {header && (
+        <div className="flex items-baseline justify-between gap-3 mb-3 pb-2 border-b">
+          <h2 className="text-sm font-semibold tracking-tight">{header}</h2>
+          {headerHint && (
+            <span className="text-xs text-muted-foreground">{headerHint}</span>
+          )}
+        </div>
+      )}
       <div
         className={
           viewMode === "grid"
@@ -269,7 +330,7 @@ function PoolGrid({
         ))}
       </div>
       {hasMore && <div ref={sentinelRef} className="h-px w-full" />}
-    </>
+    </section>
   );
 }
 
@@ -277,10 +338,12 @@ function OffersView({
   searchTerm,
   searchTags,
   userLocation,
+  onResultCountChange,
 }: {
   searchTerm: string;
   searchTags: string[];
   userLocation: UserLocation | null;
+  onResultCountChange: (count: number | null) => void;
 }) {
   const { data: offers, isLoading } = trpc.products.marketplaceList.useQuery(
     undefined,
@@ -323,6 +386,14 @@ function OffersView({
     });
   }, [sortedOffers, searchTerm, searchTags]);
 
+  useEffect(() => {
+    if (isLoading) {
+      onResultCountChange(null);
+    } else {
+      onResultCountChange(filteredOffers.length);
+    }
+  }, [isLoading, filteredOffers.length, onResultCountChange]);
+
   if (isLoading) {
     return (
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 sm:gap-4">
@@ -362,20 +433,44 @@ function OfferGrid({ offers }: { offers: OfferWithDistance[] }) {
               imageUrl={offer.image_url || null}
               locationLabel={offer.location_name || null}
               priceDisplay={
-                offer.price ? (
-                  <p className="text-xs font-bold tabular-nums whitespace-nowrap mt-0.5">
-                    {truncateByDecimalPlace(offer.price, 2)}{" "}
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {offer.voucher_symbol}
-                    </span>
-                    {offer.unit && (
-                      <span className="text-xs text-muted-foreground">
-                        {" "}
-                        / {offer.unit}
-                      </span>
-                    )}
-                  </p>
-                ) : undefined
+                offer.price
+                  ? (() => {
+                      // Convert voucher-denominated price to its unit of account when
+                      // the voucher exposes a value/UoA pair; fall back to the raw
+                      // voucher symbol otherwise. Per voucher metadata convention:
+                      //   1 voucherSymbol = voucher_value voucher_uoa
+                      const numericPrice = Number(offer.price);
+                      const canConvertToUoa =
+                        Number.isFinite(numericPrice) &&
+                        offer.voucher_value > 0 &&
+                        !!offer.voucher_uoa;
+                      const display = canConvertToUoa
+                        ? formatCurrencyValue(
+                            numericPrice * offer.voucher_value,
+                            offer.voucher_uoa,
+                            { maximumFractionDigits: 2 },
+                          )
+                        : null;
+                      return (
+                        <p className="text-xs font-bold tabular-nums whitespace-nowrap mt-0.5">
+                          {display ?? (
+                            <>
+                              {truncateByDecimalPlace(offer.price, 2)}{" "}
+                              <span className="text-xs font-medium text-muted-foreground">
+                                {offer.voucher_symbol}
+                              </span>
+                            </>
+                          )}
+                          {offer.unit && (
+                            <span className="text-xs text-muted-foreground">
+                              {" "}
+                              / {offer.unit}
+                            </span>
+                          )}
+                        </p>
+                      );
+                    })()
+                  : undefined
               }
             >
               {offer.distance_km != null && (
@@ -399,6 +494,8 @@ export function MarketplacePage() {
   const deferredSearchTerm = useDeferredValue(searchTerm);
   const [searchTags, setSearchTags] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [sortMode, setSortMode] = useState<SortMode>("auto");
+  const [resultCount, setResultCount] = useState<number | null>(null);
   const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
   const [locationStatus, setLocationStatus] =
     useState<LocationStatus>("idle");
@@ -496,15 +593,21 @@ export function MarketplacePage() {
 
         <div className="flex flex-wrap items-center gap-2">
           <Button
-            variant={locationStatus === "granted" ? "default" : "outline"}
+            variant="default"
             size="sm"
             onClick={requestLocation}
             disabled={locationStatus === "requesting"}
-            className="gap-1.5"
+            className={
+              locationStatus === "idle"
+                ? "gap-1.5 shadow-sm ring-2 ring-primary/30 ring-offset-1"
+                : "gap-1.5"
+            }
             title={
               locationStatus === "granted"
                 ? "Showing items near you — tap to refresh"
-                : "Use my location to sort by distance"
+                : locationStatus === "denied"
+                  ? "Location permission denied — enable it in your browser to sort by distance"
+                  : "Use my location to sort by distance"
             }
           >
             <LocateFixed className="h-4 w-4" />
@@ -514,10 +617,10 @@ export function MarketplacePage() {
                 ? "Near you"
                 : locationStatus === "denied"
                   ? "Location off"
-                  : "Near me"}
+                  : "Sort by distance"}
           </Button>
 
-          <div className="min-w-[10rem] flex-1 sm:flex-none sm:w-64">
+          <div className="min-w-[10rem] flex-1 sm:flex-none sm:w-56">
             <MultiSelect
               options={tagOptions}
               selected={searchTags}
@@ -525,6 +628,37 @@ export function MarketplacePage() {
               placeholder="Filter by tags"
             />
           </div>
+
+          {isPoolsTab && (
+            <Select
+              value={sortMode}
+              onValueChange={(value) => setSortMode(value as SortMode)}
+            >
+              <SelectTrigger className="h-9 w-auto min-w-[10rem] gap-2 px-3 text-sm">
+                <SelectValue placeholder="Sort by" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">
+                  <span className="flex items-center gap-2">
+                    <LocateFixed className="h-3.5 w-3.5" />
+                    {userLocation ? "Nearest" : "Most active"}
+                  </span>
+                </SelectItem>
+                <SelectItem value="swaps">
+                  <span className="flex items-center gap-2">
+                    <Activity className="h-3.5 w-3.5" />
+                    Most active
+                  </span>
+                </SelectItem>
+                <SelectItem value="name">
+                  <span className="flex items-center gap-2">
+                    <ArrowDownAZ className="h-3.5 w-3.5" />
+                    Name (A–Z)
+                  </span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          )}
 
           {isPoolsTab && (
             <ToggleGroup
@@ -542,6 +676,27 @@ export function MarketplacePage() {
             </ToggleGroup>
           )}
         </div>
+
+        <div
+          className="text-xs text-muted-foreground"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {resultCount == null
+            ? "\u00a0"
+            : (() => {
+                const noun = isPoolsTab
+                  ? resultCount === 1
+                    ? "pool"
+                    : "pools"
+                  : resultCount === 1
+                    ? "offer"
+                    : "offers";
+                return userLocation
+                  ? `${resultCount.toLocaleString()} ${noun} near you`
+                  : `${resultCount.toLocaleString()} ${noun}`;
+              })()}
+        </div>
       </div>
 
       <TabsContent value="pools" className="mt-6">
@@ -550,6 +705,8 @@ export function MarketplacePage() {
           searchTags={searchTags}
           viewMode={viewMode}
           userLocation={userLocation}
+          sortMode={sortMode}
+          onResultCountChange={setResultCount}
         />
       </TabsContent>
 
@@ -558,6 +715,7 @@ export function MarketplacePage() {
           searchTerm={deferredSearchTerm}
           searchTags={searchTags}
           userLocation={userLocation}
+          onResultCountChange={setResultCount}
         />
       </TabsContent>
     </Tabs>

--- a/src/components/pools/pool-list-item.tsx
+++ b/src/components/pools/pool-list-item.tsx
@@ -29,7 +29,12 @@ interface Pool {
 interface PoolListItemProps {
   pool: Pool;
   viewMode: "grid" | "list";
+  priority?: boolean;
 }
+
+const GRID_BANNER_SIZES =
+  "(min-width: 1280px) 25vw, (min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw";
+const LIST_THUMB_SIZES = "48px";
 
 function PoolStats({
   swap_count,
@@ -83,7 +88,11 @@ function PoolStats({
   );
 }
 
-export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
+export function PoolListItem({
+  pool,
+  viewMode,
+  priority = false,
+}: PoolListItemProps) {
   if (viewMode === "list") {
     return (
       <Link href={`/pools/${pool.contract_address}`}>
@@ -94,6 +103,8 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
                 src={pool.banner_url ?? "/pools/pool-default.webp"}
                 alt={pool.pool_name}
                 fill
+                sizes={LIST_THUMB_SIZES}
+                priority={priority}
                 className="object-cover transition-transform duration-200 group-hover:scale-110"
               />
             </div>
@@ -235,6 +246,8 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
             src={pool.banner_url ?? "/pools/pool-default.webp"}
             alt={pool.pool_name}
             fill
+            sizes={GRID_BANNER_SIZES}
+            priority={priority}
             className="object-cover transition-transform group-hover:scale-105"
           />
           <PoolStats

--- a/src/components/pools/pool-list-item.tsx
+++ b/src/components/pools/pool-list-item.tsx
@@ -36,6 +36,76 @@ const GRID_BANNER_SIZES =
   "(min-width: 1280px) 25vw, (min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw";
 const LIST_THUMB_SIZES = "48px";
 
+// Deterministic 32-bit hash so the same address always renders the same colour pair.
+function hashString(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) - h + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function gradientFromSeed(seed: string): string {
+  const hue1 = hashString(seed) % 360;
+  const hue2 = (hue1 + 47) % 360;
+  return `linear-gradient(135deg, hsl(${hue1} 55% 48%), hsl(${hue2} 60% 38%))`;
+}
+
+function initialsFromPool(name: string, symbol: string): string {
+  const cleanedName = name.trim();
+  const words = cleanedName.split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return (words[0]!.charAt(0) + words[1]!.charAt(0)).toUpperCase();
+  }
+  const fallback = (cleanedName || symbol || "??").replace(/[^a-z0-9]/gi, "");
+  return fallback.slice(0, 2).toUpperCase() || "??";
+}
+
+function PoolBanner({
+  pool,
+  variant,
+  priority,
+}: {
+  pool: Pool;
+  variant: "grid" | "thumb";
+  priority?: boolean;
+}) {
+  if (pool.banner_url) {
+    return (
+      <Image
+        src={pool.banner_url}
+        alt={pool.pool_name}
+        fill
+        sizes={variant === "grid" ? GRID_BANNER_SIZES : LIST_THUMB_SIZES}
+        priority={priority}
+        className={cn(
+          "object-cover transition-transform duration-200",
+          variant === "grid"
+            ? "group-hover:scale-105"
+            : "group-hover:scale-110",
+        )}
+      />
+    );
+  }
+
+  const initials = initialsFromPool(pool.pool_name, pool.pool_symbol);
+  return (
+    <div
+      role="img"
+      aria-label={pool.pool_name}
+      className={cn(
+        "absolute inset-0 flex items-center justify-center font-bold text-white/95 select-none",
+        variant === "grid"
+          ? "text-3xl sm:text-5xl tracking-wider"
+          : "text-xs tracking-wide",
+      )}
+      style={{ backgroundImage: gradientFromSeed(pool.contract_address) }}
+    >
+      {initials}
+    </div>
+  );
+}
+
 function PoolStats({
   swap_count,
   voucher_count,
@@ -79,7 +149,7 @@ function PoolStats({
         <Badge
           key={label}
           variant="secondary"
-          className="bg-black/70 text-white text-xs sm:text-sm whitespace-nowrap transition-colors duration-200 hover:bg-black/80"
+          className="bg-black/60 text-white text-xs sm:text-sm whitespace-nowrap backdrop-blur-md ring-1 ring-white/10 transition-colors duration-200 hover:bg-black/75"
         >
           {value.toLocaleString()} {label}
         </Badge>
@@ -99,14 +169,7 @@ export function PoolListItem({
         <div className="flex flex-col xs:flex-row gap-3 xs:gap-4 py-4 px-4 xs:px-6 hover:bg-muted/50 rounded-lg transition-all duration-200 group relative before:absolute before:inset-x-4 before:top-0 before:h-px before:bg-border/50 first:before:hidden">
           <div className="flex gap-3 items-start xs:items-center">
             <div className="relative h-10 w-10 xs:h-12 xs:w-12 flex-shrink-0 rounded-lg overflow-hidden shadow-xs">
-              <Image
-                src={pool.banner_url ?? "/pools/pool-default.webp"}
-                alt={pool.pool_name}
-                fill
-                sizes={LIST_THUMB_SIZES}
-                priority={priority}
-                className="object-cover transition-transform duration-200 group-hover:scale-110"
-              />
+              <PoolBanner pool={pool} variant="thumb" priority={priority} />
             </div>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
@@ -238,37 +301,22 @@ export function PoolListItem({
     );
   }
 
+  // Grid card uses fixed-height sections so cards align uniformly across the grid.
   return (
     <Link href={`/pools/${pool.contract_address}`}>
-      <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 h-[400px] flex flex-col group">
-        <div className="relative h-48 w-full flex-shrink-0">
-          <Image
-            src={pool.banner_url ?? "/pools/pool-default.webp"}
-            alt={pool.pool_name}
-            fill
-            sizes={GRID_BANNER_SIZES}
-            priority={priority}
-            className="object-cover transition-transform group-hover:scale-105"
-          />
+      <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 h-[380px] flex flex-col group">
+        <div className="relative h-44 w-full flex-shrink-0">
+          <PoolBanner pool={pool} variant="grid" priority={priority} />
           <PoolStats
             swap_count={pool.swap_count}
             voucher_count={pool.voucher_count}
             className="absolute bottom-2 right-2"
           />
-          {pool.distance_km != null && (
-            <Badge
-              variant="secondary"
-              className="absolute bottom-2 left-2 bg-black/70 text-white text-xs flex items-center gap-1 whitespace-nowrap"
-            >
-              <MapPin className="h-3 w-3" />
-              {formatDistanceKm(pool.distance_km)}
-            </Badge>
-          )}
         </div>
-        <CardHeader className="flex-shrink-0 space-y-1">
+        <CardHeader className="flex-shrink-0 pb-2">
           <div className="flex items-start gap-2">
             <h3
-              className="text-lg sm:text-2xl font-bold line-clamp-1 flex-1"
+              className="text-base sm:text-lg font-bold line-clamp-2 leading-tight flex-1 h-[2.6rem] sm:h-[3.5rem]"
               title={pool.pool_name}
             >
               {pool.pool_name}
@@ -276,7 +324,7 @@ export function PoolListItem({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                  <Info className="h-4 w-4 text-muted-foreground flex-shrink-0 mt-1" />
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>Contract: {pool.contract_address}</p>
@@ -285,15 +333,24 @@ export function PoolListItem({
               </Tooltip>
             </TooltipProvider>
           </div>
-          <p className="text-xs sm:text-sm text-muted-foreground">
-            {pool.pool_symbol}
-          </p>
+          <div className="h-5 mt-1">
+            {pool.distance_km != null ? (
+              <p className="flex items-center gap-1 text-xs sm:text-sm text-muted-foreground line-clamp-1">
+                <MapPin className="h-3 w-3 flex-shrink-0" />
+                {formatDistanceKm(pool.distance_km)} away
+              </p>
+            ) : (
+              <p className="text-xs sm:text-sm text-muted-foreground line-clamp-1">
+                {pool.pool_symbol}
+              </p>
+            )}
+          </div>
         </CardHeader>
-        <CardContent className="flex-1 flex flex-col justify-between">
-          <p className="text-xs sm:text-sm text-muted-foreground line-clamp-2">
+        <CardContent className="flex-1 flex flex-col gap-3 pt-0">
+          <p className="text-xs sm:text-sm text-muted-foreground line-clamp-2 h-10 leading-5">
             {pool.description}
           </p>
-          <div className="flex flex-nowrap items-center gap-1 sm:gap-2 mt-4 min-w-0 overflow-hidden">
+          <div className="flex flex-nowrap items-center gap-1 sm:gap-2 mt-auto h-6 min-w-0 overflow-hidden">
             {pool.tags.slice(0, 2).map((tag) => (
               <Badge
                 key={tag}

--- a/src/components/pools/pool-list-item.tsx
+++ b/src/components/pools/pool-list-item.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Info } from "lucide-react";
+import { Info, MapPin } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "~/lib/utils";
+import { formatDistanceKm } from "~/utils/units/geo";
 import { Badge } from "../ui/badge";
 import { Card, CardContent, CardHeader } from "../ui/card";
 import {
@@ -22,6 +23,7 @@ interface Pool {
   tags: string[];
   swap_count: number;
   voucher_count: number;
+  distance_km?: number | null;
 }
 
 interface PoolListItemProps {
@@ -53,7 +55,7 @@ function PoolStats({
             key={label}
             className={cn(
               "flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-muted/50 hover:bg-muted transition-colors duration-200",
-              index === 0 && "xs:border-r xs:border-border/50 xs:pr-3"
+              index === 0 && "xs:border-r xs:border-border/50 xs:pr-3",
             )}
           >
             <span className="font-medium text-xs xs:text-sm">
@@ -117,6 +119,12 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
               <p className="text-xs xs:text-sm text-muted-foreground">
                 {pool.pool_symbol}
               </p>
+              {pool.distance_km != null && (
+                <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                  <MapPin className="h-3 w-3" />
+                  {formatDistanceKm(pool.distance_km)} away
+                </p>
+              )}
             </div>
           </div>
           <div className="flex flex-col xs:flex-row gap-2 xs:gap-4 flex-1 items-start">
@@ -170,12 +178,13 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
                 className="text-muted-foreground"
               />
             </div>
-            <div className="hidden xs:flex sm:flex-wrap gap-1 w-32">
+            <div className="hidden xs:flex sm:flex-wrap gap-1 w-32 min-w-0">
               {pool.tags.slice(0, 2).map((tag) => (
                 <Badge
                   key={tag}
                   variant="secondary"
-                  className="text-xs px-2 py-0.5 transition-colors duration-200 hover:bg-secondary/70"
+                  className="text-xs px-2 py-0.5 max-w-full truncate transition-colors duration-200 hover:bg-secondary/70"
+                  title={tag}
                 >
                   {tag}
                 </Badge>
@@ -233,6 +242,15 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
             voucher_count={pool.voucher_count}
             className="absolute bottom-2 right-2"
           />
+          {pool.distance_km != null && (
+            <Badge
+              variant="secondary"
+              className="absolute bottom-2 left-2 bg-black/70 text-white text-xs flex items-center gap-1 whitespace-nowrap"
+            >
+              <MapPin className="h-3 w-3" />
+              {formatDistanceKm(pool.distance_km)}
+            </Badge>
+          )}
         </div>
         <CardHeader className="flex-shrink-0 space-y-1">
           <div className="flex items-start gap-2">
@@ -262,12 +280,13 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
           <p className="text-xs sm:text-sm text-muted-foreground line-clamp-2">
             {pool.description}
           </p>
-          <div className="flex flex-wrap gap-1 sm:gap-2 mt-4">
+          <div className="flex flex-nowrap items-center gap-1 sm:gap-2 mt-4 min-w-0 overflow-hidden">
             {pool.tags.slice(0, 2).map((tag) => (
               <Badge
                 key={tag}
                 variant="secondary"
-                className="text-xs sm:text-sm"
+                className="text-xs sm:text-sm min-w-0 truncate"
+                title={tag}
               >
                 {tag}
               </Badge>
@@ -278,7 +297,7 @@ export function PoolListItem({ pool, viewMode }: PoolListItemProps) {
                   <TooltipTrigger asChild>
                     <Badge
                       variant="outline"
-                      className="text-xs sm:text-sm cursor-help"
+                      className="text-xs sm:text-sm cursor-help shrink-0"
                     >
                       +{pool.tags.length - 2}
                     </Badge>

--- a/src/components/pools/pool-list.tsx
+++ b/src/components/pools/pool-list.tsx
@@ -380,11 +380,12 @@ export function PoolList({ searchTerm, searchTags }: PoolListProps) {
             onSort={toggleSort}
           />
         )}
-        {filteredPools.map((pool) => (
+        {filteredPools.map((pool, index) => (
           <PoolListItem
             key={pool.contract_address}
             pool={pool}
             viewMode={viewMode}
+            priority={index === 0}
           />
         ))}
       </div>

--- a/src/components/pools/pool-offers-grid.tsx
+++ b/src/components/pools/pool-offers-grid.tsx
@@ -21,6 +21,7 @@ import { ResponsiveModal } from "~/components/responsive-modal";
 import { useAuth } from "~/hooks/use-auth";
 import { trpc, type RouterOutputs } from "~/lib/trpc";
 import { type RouterOutput } from "~/server/api/root";
+import { distanceKmBetweenPoints } from "~/utils/units/geo";
 import { formatCurrencyValue } from "~/utils/units/number";
 import { fromRawPriceIndex } from "~/utils/units/pool";
 import { Badge } from "../ui/badge";
@@ -55,22 +56,6 @@ interface SelectedSwapProduct {
 type Product = RouterOutput["products"]["list"][number];
 type ProductWithDistance = Product & { _distanceKm: number | null };
 
-function haversineDistanceKm(
-  a: { x: number; y: number },
-  b: { x: number; y: number },
-): number {
-  const R = 6371;
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(b.x - a.x);
-  const dLon = toRad(b.y - a.y);
-  const sinLat = Math.sin(dLat / 2);
-  const sinLon = Math.sin(dLon / 2);
-  const h =
-    sinLat * sinLat +
-    Math.cos(toRad(a.x)) * Math.cos(toRad(b.x)) * sinLon * sinLon;
-  return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
-}
-
 function formatDistance(km: number): string {
   if (km < 1) return "< 1 km";
   if (km < 5) return "< 5 km";
@@ -79,21 +64,6 @@ function formatDistance(km: number): string {
   if (km < 50) return "< 50 km";
   if (km < 100) return "< 100 km";
   return "100+ km";
-}
-
-function getDistanceKm(
-  userGeo: { x: number; y: number } | null | undefined,
-  voucherGeo: { x: number; y: number } | null | undefined,
-): number | null {
-  if (!userGeo || !voucherGeo) return null;
-  if (!Number.isFinite(userGeo.x) || !Number.isFinite(userGeo.y)) return null;
-  if (!Number.isFinite(voucherGeo.x) || !Number.isFinite(voucherGeo.y))
-    return null;
-  const clamp = (geo: { x: number; y: number }) => ({
-    x: Math.max(-90, Math.min(90, geo.x)),
-    y: Math.max(-180, Math.min(180, geo.y)),
-  });
-  return haversineDistanceKm(clamp(userGeo), clamp(voucherGeo));
 }
 
 function PoolOfferGridCard({
@@ -140,7 +110,9 @@ function PoolOfferGridCard({
         priceInDV !== undefined && priceInDV > MIN_SWAP_AMOUNT ? (
           <p className="text-xs font-bold tabular-nums whitespace-nowrap mt-0.5">
             {formatCurrencyValue(priceInDV, defaultVoucherSymbol)}
-            <span className="text-xs text-muted-foreground">/{product.unit || "Unit"}</span>
+            <span className="text-xs text-muted-foreground">
+              /{product.unit || "Unit"}
+            </span>
           </p>
         ) : undefined
       }
@@ -154,14 +126,15 @@ function PoolOfferGridCard({
               className="text-[11px] font-light leading-tight truncate hover:underline block"
               onClick={(e) => e.stopPropagation()}
             >
-              View{" "}
-              {product.voucher_name ?? product.voucher_symbol ?? "Voucher"}
+              View {product.voucher_name ?? product.voucher_symbol ?? "Voucher"}
             </Link>
             {availableToSwap > MIN_SWAP_AMOUNT && (
               <p className="text-[10px] text-green-600 leading-tight">
                 Credit{" "}
                 <span className="tabular-nums font-medium">
-                  {formatCurrencyValue(availableToSwap, defaultVoucherSymbol, { maximumFractionDigits: 2 })}
+                  {formatCurrencyValue(availableToSwap, defaultVoucherSymbol, {
+                    maximumFractionDigits: 2,
+                  })}
                 </span>
               </p>
             )}
@@ -261,7 +234,9 @@ function OfferDetailContent({
         {priceInDV !== undefined && priceInDV > MIN_SWAP_AMOUNT && (
           <p className="text-lg font-bold tabular-nums whitespace-nowrap">
             {formatCurrencyValue(priceInDV, defaultVoucherSymbol)}
-            <span className="text-base font-normal text-muted-foreground">/{product.unit || "Unit"}</span>
+            <span className="text-base font-normal text-muted-foreground">
+              /{product.unit || "Unit"}
+            </span>
           </p>
         )}
       </div>
@@ -302,7 +277,9 @@ function OfferDetailContent({
             <p className="text-xs text-green-600">
               Credit{" "}
               <span className="tabular-nums font-medium">
-                {formatCurrencyValue(availableToSwap, defaultVoucherSymbol, { maximumFractionDigits: 2 })}
+                {formatCurrencyValue(availableToSwap, defaultVoucherSymbol, {
+                  maximumFractionDigits: 2,
+                })}
               </span>
             </p>
           )}
@@ -375,7 +352,10 @@ export function PoolOffersGrid({ pool, metadata }: PoolOffersGridProps) {
     voucher_addresses: pool.vouchers ?? [],
   });
 
-  const products = allProducts?.flat().filter(Boolean) ?? [];
+  const products = useMemo(
+    () => allProducts?.flat().filter(Boolean) ?? [],
+    [allProducts],
+  );
 
   const { data: voucherInfo } = trpc.voucher.byAddress.useQuery(
     { voucherAddress: selectedProduct?.voucher_address ?? "" },
@@ -390,58 +370,56 @@ export function PoolOffersGrid({ pool, metadata }: PoolOffersGridProps) {
     return map;
   }, [pool.voucherDetails]);
 
-  const filteredProducts = products.filter((product) => {
-    return (
-      searchTerm === "" ||
-      product.commodity_name.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  });
-
   const userGeo = auth?.user?.geo;
 
-  const sortedProducts = useMemo(() => {
-    const enriched: ProductWithDistance[] = filteredProducts.map((p) => ({
+  const enrichedProducts = useMemo<ProductWithDistance[]>(() => {
+    return products.map((p) => ({
       ...p,
-      _distanceKm: getDistanceKm(userGeo, p.voucher_geo),
+      _distanceKm: distanceKmBetweenPoints(userGeo, p.voucher_geo),
     }));
+  }, [products, userGeo]);
+
+  const filteredProducts = useMemo(() => {
+    if (searchTerm === "") return enrichedProducts;
+    const term = searchTerm.toLowerCase();
+    return enrichedProducts.filter((p) =>
+      p.commodity_name.toLowerCase().includes(term),
+    );
+  }, [enrichedProducts, searchTerm]);
+
+  const sortedProducts = useMemo(() => {
+    const arr = [...filteredProducts];
     if (sortBy === "name") {
-      enriched.sort((a, b) =>
-        a.commodity_name.localeCompare(b.commodity_name),
-      );
+      arr.sort((a, b) => a.commodity_name.localeCompare(b.commodity_name));
     } else if (sortBy === "distance") {
-      enriched.sort((a, b) => {
+      arr.sort((a, b) => {
         if (a._distanceKm === null && b._distanceKm === null) return 0;
         if (a._distanceKm === null) return 1;
         if (b._distanceKm === null) return -1;
         return a._distanceKm - b._distanceKm;
       });
     } else {
-      enriched.sort((a, b) => {
-        const detailA = voucherDetailMap.get(a.voucher_address.toLowerCase());
-        const detailB = voucherDetailMap.get(b.voucher_address.toLowerCase());
-        const creditA = isConnected
-          ? getTotalPurchasingPower(
-              a.voucher_address,
-              detailA,
-              voucherDetailMap,
-            )
-          : detailA
-            ? getHoldingInDefaultVoucherUnits(detailA)
+      // Pre-compute credit per item once to avoid O(n log n) recomputation in comparator.
+      const creditByAddress = new Map<string, number>();
+      for (const p of arr) {
+        const key = p.voucher_address.toLowerCase();
+        if (creditByAddress.has(key)) continue;
+        const detail = voucherDetailMap.get(key);
+        const credit = isConnected
+          ? getTotalPurchasingPower(p.voucher_address, detail, voucherDetailMap)
+          : detail
+            ? getHoldingInDefaultVoucherUnits(detail)
             : 0;
-        const creditB = isConnected
-          ? getTotalPurchasingPower(
-              b.voucher_address,
-              detailB,
-              voucherDetailMap,
-            )
-          : detailB
-            ? getHoldingInDefaultVoucherUnits(detailB)
-            : 0;
-        return creditB - creditA;
+        creditByAddress.set(key, credit);
+      }
+      arr.sort((a, b) => {
+        const ca = creditByAddress.get(a.voucher_address.toLowerCase()) ?? 0;
+        const cb = creditByAddress.get(b.voucher_address.toLowerCase()) ?? 0;
+        return cb - ca;
       });
     }
-    return enriched;
-  }, [filteredProducts, sortBy, isConnected, voucherDetailMap, userGeo]);
+    return arr;
+  }, [filteredProducts, sortBy, isConnected, voucherDetailMap]);
 
   const handleSwapClick = (
     voucherAddress: `0x${string}`,
@@ -579,16 +557,14 @@ export function PoolOffersGrid({ pool, metadata }: PoolOffersGridProps) {
             distanceKm={
               sortedProducts.find((p) => p.id === selectedProduct.id)
                 ?._distanceKm ??
-              getDistanceKm(userGeo, selectedProduct.voucher_geo)
+              distanceKmBetweenPoints(userGeo, selectedProduct.voucher_geo)
             }
             isConnected={isConnected}
             onSwap={() => {
               setSelectedProduct(null);
               handleSwapClick(
                 selectedProduct.voucher_address,
-                selectedProduct.price
-                  ? String(selectedProduct.price)
-                  : null,
+                selectedProduct.price ? String(selectedProduct.price) : null,
               );
             }}
           />

--- a/src/config/site.tsx
+++ b/src/config/site.tsx
@@ -3,6 +3,7 @@ import {
   ChartNetwork,
   FolderCode,
   Home,
+  Info,
   LayoutDashboard,
   MapIcon,
   Newspaper,
@@ -73,13 +74,18 @@ const siteConfig: {
       items: [
         {
           icon: <Home size={18} />,
-          title: "Home",
+          title: "Marketplace",
           href: "/",
         },
         {
           icon: <LayoutDashboard size={18} />,
           title: "Dashboard",
           href: "/dashboard",
+        },
+        {
+          icon: <Info size={18} />,
+          title: "About",
+          href: "/about",
         },
         {
           icon: <MapIcon size={18} />,

--- a/src/server/api/models/pool.ts
+++ b/src/server/api/models/pool.ts
@@ -198,6 +198,7 @@ export class PoolModel {
         "pool_name",
         "swap_pool_description",
         "banner_url",
+        "geo",
       ])
       .execute();
 
@@ -227,6 +228,7 @@ export class PoolModel {
         pool_symbol: cp.pool_symbol,
         description: gp?.swap_pool_description ?? "",
         banner_url: gp?.banner_url ?? null,
+        geo: gp?.geo ?? null,
         tags:
           (gp?.id != null ? tagMap.get(gp.id) : undefined)?.filter(
             Boolean

--- a/src/server/api/routers/products.ts
+++ b/src/server/api/routers/products.ts
@@ -45,6 +45,8 @@ export const productsRouter = router({
             "vouchers.voucher_name",
             sql<string>`vouchers.symbol`.as("voucher_symbol"),
             sql<string | null>`vouchers.icon_url`.as("voucher_icon"),
+            "vouchers.voucher_value",
+            "vouchers.voucher_uoa",
           ])
           .orderBy("product_listings.created_at", "desc")
           .limit(MARKETPLACE_LIST_LIMIT)

--- a/src/server/api/routers/products.ts
+++ b/src/server/api/routers/products.ts
@@ -14,14 +14,136 @@ import {
   router,
 } from "~/server/api/trpc";
 import { type CommodityType } from "~/server/enums";
+import { cacheQuery, invalidateTag } from "~/utils/cache/cacheQuery";
 import { hasPermission } from "~/utils/permissions";
 
+const MARKETPLACE_LIST_LIMIT = 500;
+
 export const productsRouter = router({
+  marketplaceList: publicProcedure.query(
+    cacheQuery(
+      60,
+      async ({ ctx }) => {
+        const offers = await ctx.graphDB
+          .selectFrom("product_listings")
+          .innerJoin("vouchers", "product_listings.voucher", "vouchers.id")
+          .where("product_listings.commodity_available", "=", true)
+          .where("vouchers.active", "=", true)
+          .select([
+            "product_listings.id",
+            "product_listings.commodity_name",
+            "product_listings.commodity_description",
+            sql<keyof typeof CommodityType>`product_listings.commodity_type`.as(
+              "commodity_type",
+            ),
+            "product_listings.image_url",
+            "product_listings.price",
+            "product_listings.unit",
+            "product_listings.location_name",
+            "vouchers.geo as voucher_geo",
+            sql<`0x${string}`>`vouchers.voucher_address`.as("voucher_address"),
+            "vouchers.voucher_name",
+            sql<string>`vouchers.symbol`.as("voucher_symbol"),
+            sql<string | null>`vouchers.icon_url`.as("voucher_icon"),
+          ])
+          .orderBy("product_listings.created_at", "desc")
+          .limit(MARKETPLACE_LIST_LIMIT)
+          .execute();
+
+        if (offers.length === 0) return [];
+
+        const offerIds = offers.map((o) => o.id);
+        const tagRows = await ctx.graphDB
+          .selectFrom("product_listing_tags")
+          .innerJoin("tags", "product_listing_tags.tag", "tags.id")
+          .where("product_listing_tags.product_listing", "in", offerIds)
+          .select(["product_listing_tags.product_listing as listing_id", "tags.tag"])
+          .execute();
+
+        const tagsByListing = new Map<number, string[]>();
+        for (const row of tagRows) {
+          const list = tagsByListing.get(row.listing_id);
+          if (list) {
+            list.push(row.tag);
+          } else {
+            tagsByListing.set(row.listing_id, [row.tag]);
+          }
+        }
+
+        const offersWithTags = offers.map((o) => ({
+          ...o,
+          tags: tagsByListing.get(o.id) ?? [],
+        }));
+
+        // Fall back to swap-pool geo only for offers whose voucher has no geo
+        // — many vouchers lack geo but the pools that include them have one.
+        const vouchersNeedingFallback = Array.from(
+          new Set(
+            offersWithTags
+              .filter((o) => o.voucher_geo == null)
+              .map((o) => o.voucher_address),
+          ),
+        );
+
+        if (vouchersNeedingFallback.length === 0) {
+          return offersWithTags;
+        }
+
+        const poolTokens = await ctx.federatedDB
+          .selectFrom("pool_router.pool_allowed_tokens")
+          .where("token_address", "in", vouchersNeedingFallback)
+          .select(["token_address", "pool_address"])
+          .execute();
+
+        if (poolTokens.length === 0) return offersWithTags;
+
+        const poolAddresses = Array.from(
+          new Set(poolTokens.map((p) => p.pool_address)),
+        );
+
+        const poolGeos = await ctx.graphDB
+          .selectFrom("swap_pools")
+          .where("pool_address", "in", poolAddresses)
+          .where("geo", "is not", null)
+          .select(["pool_address", "geo"])
+          .execute();
+
+        if (poolGeos.length === 0) return offersWithTags;
+
+        const poolGeoMap = new Map(
+          poolGeos.map((p) => [p.pool_address, p.geo]),
+        );
+
+        const voucherFallbackGeo = new Map<
+          string,
+          { x: number; y: number } | null
+        >();
+        for (const pt of poolTokens) {
+          if (voucherFallbackGeo.has(pt.token_address)) continue;
+          const geo = poolGeoMap.get(pt.pool_address);
+          if (geo) voucherFallbackGeo.set(pt.token_address, geo);
+        }
+
+        if (voucherFallbackGeo.size === 0) return offersWithTags;
+
+        return offersWithTags.map((offer) =>
+          offer.voucher_geo
+            ? offer
+            : {
+                ...offer,
+                voucher_geo:
+                  voucherFallbackGeo.get(offer.voucher_address) ?? null,
+              },
+        );
+      },
+      { tags: ["product_listings", "vouchers", "swap_pools"] },
+    ),
+  ),
   nearbyOffers: publicProcedure
     .input(
       z.object({
         limit: z.number().min(1).max(50).default(10),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const offers = await ctx.graphDB
@@ -75,7 +197,7 @@ export const productsRouter = router({
     .input(
       z.object({
         voucher_addresses: z.array(z.string()).optional(),
-      })
+      }),
     )
     .query(({ ctx, input }) => {
       let query = ctx.graphDB
@@ -88,7 +210,7 @@ export const productsRouter = router({
           "product_listings.commodity_name",
           "product_listings.commodity_description",
           sql<keyof typeof CommodityType>`product_listings.commodity_type`.as(
-            "commodity_type"
+            "commodity_type",
           ),
           "product_listings.quantity",
           "product_listings.frequency",
@@ -110,7 +232,7 @@ export const productsRouter = router({
       query = query.where(
         "vouchers.voucher_address",
         "in",
-        input.voucher_addresses
+        input.voucher_addresses,
       );
       return query.execute();
     }),
@@ -118,7 +240,7 @@ export const productsRouter = router({
     .input(
       z.object({
         id: z.number(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const product = await ctx.graphDB
@@ -177,6 +299,7 @@ export const productsRouter = router({
         );
       }
 
+      void invalidateTag("product_listings");
       return productListing;
     }),
   update: authenticatedProcedure
@@ -192,7 +315,7 @@ export const productsRouter = router({
       const isContractOwner = await getIsContractOwner(
         publicClient,
         ctx.session.address,
-        voucher_address as `0x${string}`
+        voucher_address as `0x${string}`,
       );
       if (!hasPermission(ctx.user, isContractOwner, "Products", "UPDATE")) {
         throw new TRPCError({
@@ -233,13 +356,14 @@ export const productsRouter = router({
         );
       }
 
+      void invalidateTag("product_listings");
       return updatedProductListing;
     }),
   remove: authenticatedProcedure
     .input(
       z.object({
         id: z.number(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const voucher = await ctx.graphDB
@@ -252,7 +376,7 @@ export const productsRouter = router({
       const isContractOwner = await getIsContractOwner(
         publicClient,
         ctx.session.address,
-        voucher_address as `0x${string}`
+        voucher_address as `0x${string}`,
       );
 
       if (!hasPermission(ctx.user, isContractOwner, "Products", "DELETE")) {
@@ -280,6 +404,7 @@ export const productsRouter = router({
           });
         });
 
+      void invalidateTag("product_listings");
       return transactionResult;
     }),
 });

--- a/src/utils/units/__tests__/geo.test.ts
+++ b/src/utils/units/__tests__/geo.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampLatLng,
+  distanceKmFromPoint,
+  formatDistanceKm,
+  haversineKm,
+  latLngToPoint,
+  pointToLatLng,
+} from "../geo";
+
+describe("geo utilities", () => {
+  describe("pointToLatLng", () => {
+    it("maps Point.x to latitude and Point.y to longitude", () => {
+      // Nairobi is roughly (lat -1.29, lng 36.82)
+      expect(pointToLatLng({ x: -1.29, y: 36.82 })).toEqual({
+        latitude: -1.29,
+        longitude: 36.82,
+      });
+    });
+
+    it("returns null for null/undefined", () => {
+      expect(pointToLatLng(null)).toBeNull();
+      expect(pointToLatLng(undefined)).toBeNull();
+    });
+
+    it("returns null for non-finite values", () => {
+      expect(pointToLatLng({ x: Number.NaN, y: 0 })).toBeNull();
+      expect(pointToLatLng({ x: 0, y: Number.POSITIVE_INFINITY })).toBeNull();
+    });
+  });
+
+  describe("latLngToPoint", () => {
+    it("is the inverse of pointToLatLng", () => {
+      const original = { x: -1.29, y: 36.82 };
+      expect(latLngToPoint(pointToLatLng(original)!)).toEqual(original);
+    });
+  });
+
+  describe("clampLatLng", () => {
+    it("clamps latitude to ±90 and longitude to ±180", () => {
+      expect(clampLatLng({ latitude: 200, longitude: 500 })).toEqual({
+        latitude: 90,
+        longitude: 180,
+      });
+      expect(clampLatLng({ latitude: -200, longitude: -500 })).toEqual({
+        latitude: -90,
+        longitude: -180,
+      });
+    });
+  });
+
+  describe("haversineKm", () => {
+    it("returns 0 for identical points", () => {
+      const p = { latitude: -1.29, longitude: 36.82 };
+      expect(haversineKm(p, p)).toBe(0);
+    });
+
+    it("computes the Nairobi → Madrid distance (~6,400 km)", () => {
+      const nairobi = { latitude: -1.29, longitude: 36.82 };
+      const madrid = { latitude: 40.42, longitude: -3.7 };
+      const km = haversineKm(nairobi, madrid);
+      expect(km).toBeGreaterThan(6000);
+      expect(km).toBeLessThan(6400);
+    });
+  });
+
+  describe("distanceKmFromPoint", () => {
+    it("uses the (x=lat, y=lng) convention when measuring", () => {
+      // User in Nairobi, voucher stored as Point in Madrid.
+      const user = { latitude: -1.29, longitude: 36.82 };
+      const madridPoint = { x: 40.42, y: -3.7 };
+      const km = distanceKmFromPoint(user, madridPoint)!;
+      expect(km).toBeGreaterThan(6000);
+      expect(km).toBeLessThan(6400);
+    });
+
+    it("returns null when either side is missing", () => {
+      expect(distanceKmFromPoint(null, { x: 0, y: 0 })).toBeNull();
+      expect(
+        distanceKmFromPoint({ latitude: 0, longitude: 0 }, null),
+      ).toBeNull();
+    });
+  });
+
+  describe("formatDistanceKm", () => {
+    it("uses metres below 1 km", () => {
+      expect(formatDistanceKm(0.4)).toBe("400 m");
+    });
+    it("uses one decimal between 1 and 10 km", () => {
+      expect(formatDistanceKm(2.345)).toBe("2.3 km");
+    });
+    it("rounds to whole km above 10", () => {
+      expect(formatDistanceKm(123.7)).toBe("124 km");
+    });
+  });
+});

--- a/src/utils/units/geo.ts
+++ b/src/utils/units/geo.ts
@@ -1,0 +1,92 @@
+/**
+ * Geo conversion + distance utilities.
+ *
+ * STORAGE CONVENTION (PostgreSQL `point` columns in this codebase):
+ *   Point.x = latitude
+ *   Point.y = longitude
+ *
+ * NOTE: this is the OPPOSITE of the standard PostGIS / GeoJSON ordering
+ * (which is lon, lat). Always use these helpers when crossing the boundary
+ * between stored points and lat/lng — never read `geo.x` / `geo.y` directly.
+ */
+
+export type Point = { x: number; y: number };
+export type LatLng = { latitude: number; longitude: number };
+
+const LAT_MIN = -90;
+const LAT_MAX = 90;
+const LNG_MIN = -180;
+const LNG_MAX = 180;
+const EARTH_RADIUS_KM = 6371;
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n);
+}
+
+/** Convert a stored Point to {latitude, longitude}, or null if unusable. */
+export function pointToLatLng(point: Point | null | undefined): LatLng | null {
+  if (!point) return null;
+  if (!isFiniteNumber(point.x) || !isFiniteNumber(point.y)) return null;
+  return { latitude: point.x, longitude: point.y };
+}
+
+/** Convert {latitude, longitude} to a stored Point. */
+export function latLngToPoint(latLng: LatLng): Point {
+  return { x: latLng.latitude, y: latLng.longitude };
+}
+
+/** Clamp a LatLng into valid ranges. */
+export function clampLatLng(latLng: LatLng): LatLng {
+  return {
+    latitude: Math.max(LAT_MIN, Math.min(LAT_MAX, latLng.latitude)),
+    longitude: Math.max(LNG_MIN, Math.min(LNG_MAX, latLng.longitude)),
+  };
+}
+
+/** Great-circle distance between two LatLng points, in kilometres. */
+export function haversineKm(a: LatLng, b: LatLng): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLon = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Distance between a user's LatLng and a stored Point, in kilometres.
+ * Returns null if either input is missing or non-finite.
+ */
+export function distanceKmFromPoint(
+  user: LatLng | null | undefined,
+  point: Point | null | undefined,
+): number | null {
+  if (!user) return null;
+  const target = pointToLatLng(point);
+  if (!target) return null;
+  return haversineKm(clampLatLng(user), clampLatLng(target));
+}
+
+/**
+ * Distance between two stored Points, in kilometres.
+ * Returns null if either input is missing or non-finite.
+ */
+export function distanceKmBetweenPoints(
+  a: Point | null | undefined,
+  b: Point | null | undefined,
+): number | null {
+  const aLatLng = pointToLatLng(a);
+  const bLatLng = pointToLatLng(b);
+  if (!aLatLng || !bLatLng) return null;
+  return haversineKm(clampLatLng(aLatLng), clampLatLng(bLatLng));
+}
+
+/** Format a kilometre distance as a short human label. */
+export function formatDistanceKm(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  if (km < 10) return `${km.toFixed(1)} km`;
+  return `${Math.round(km)} km`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,8 @@
     "**/*.cjs",
     "**/*.mjs",
     ".next/types/**/*.ts",
-    "vitest.config.mts"
+    "vitest.config.mts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- Replace the landing page with a marketplace that lists pools and offers sorted by distance from the user, with searchable tag filters (multi-select), text search, view toggle, and a mobile-friendly toolbar; move old landing content to `/about`.
- Add `~/utils/units/geo` helpers (Point<->LatLng, haversine distance, formatting) with tests, and route all map/voucher/pool geo conversions through them.
- Optimize the `products.marketplaceList` tRPC endpoint: Redis caching with tag invalidation, batched `product_listing_tags` lookup, and a swap-pool geo fallback for vouchers that lack their own location; surface pool `geo` through `PoolModel.list` so distance can be computed for pools too.
- UI polish: fix tag overflow on pool cards (truncate + tooltip), progressive rendering of large grids via IntersectionObserver, sessionStorage-persisted user location with hydration-safe init, and `MultiSelect` tag filter applied to both tabs.

## Test plan
- [ ] `pnpm check-types` passes
- [ ] `pnpm test` passes (367 tests including new geo tests)
- [ ] `/` loads marketplace, pools sort by distance after granting location
- [ ] Offers tab respects tag filter; pool cards no longer overflow with long tag names
- [ ] `/about` renders the previous landing content
- [ ] No SSR hydration warnings in console after a clean dev-server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)