### PR TITLE
Rob/redeem feature

### DIFF
--- a/migrations/add-voucher-redemption-address.sql
+++ b/migrations/add-voucher-redemption-address.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vouchers ADD COLUMN IF NOT EXISTS redemption_address VARCHAR(66);

--- a/scripts/migrate-voucher-redemption-address.ts
+++ b/scripts/migrate-voucher-redemption-address.ts
@@ -1,0 +1,105 @@
+/**
+ * Migration script: Populate redemption_address for existing vouchers
+ *
+ * Prerequisites:
+ *   1. Apply migrations/add-voucher-redemption-address.sql:
+ *      ALTER TABLE vouchers ADD COLUMN IF NOT EXISTS redemption_address VARCHAR(66);
+ *   2. Set DATABASE_URL env var pointing to the graph database.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... npx tsx scripts/migrate-voucher-redemption-address.ts
+ *
+ * What it does:
+ *   - Reads all vouchers from the graph DB where redemption_address IS NULL.
+ *   - For each voucher, calls owner() on the deployed contract on Celo.
+ *   - Writes the resulting address into redemption_address.
+ *   - On read failure (non-demurrage tokens, removed contracts, RPC issues) the
+ *     row is left NULL — it can be set later via the voucher edit UI. The
+ *     Redeem flow gates on this column being non-null.
+ */
+
+import { createPublicClient, http, isAddress } from "viem";
+import { celo } from "viem/chains";
+import pg from "pg";
+
+const CELO_RPC = "https://r4-celo.grassecon.org";
+
+const ownerAbi = [
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const client = createPublicClient({
+  chain: celo,
+  transport: http(CELO_RPC),
+});
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL environment variable is required");
+    process.exit(1);
+  }
+
+  const pool = new pg.Pool({ connectionString: databaseUrl });
+
+  try {
+    const { rows } = await pool.query<{
+      id: number;
+      voucher_address: string;
+    }>(
+      "SELECT id, voucher_address FROM vouchers WHERE redemption_address IS NULL"
+    );
+
+    console.log(`Found ${rows.length} vouchers to migrate`);
+
+    let migrated = 0;
+    let failed = 0;
+
+    for (const row of rows) {
+      try {
+        const owner = await client.readContract({
+          address: row.voucher_address as `0x${string}`,
+          abi: ownerAbi,
+          functionName: "owner",
+        });
+
+        if (!isAddress(owner)) {
+          throw new Error(`Returned non-address: ${String(owner)}`);
+        }
+
+        await pool.query(
+          "UPDATE vouchers SET redemption_address = $1 WHERE id = $2",
+          [owner, row.id]
+        );
+
+        console.log(
+          `  Voucher ${row.id}: ${row.voucher_address} -> ${owner}`
+        );
+        migrated++;
+      } catch (error) {
+        console.error(
+          `  Voucher ${row.id}: Failed to read owner for ${row.voucher_address}:`,
+          (error as Error).message
+        );
+        failed++;
+      }
+    }
+
+    console.log(
+      `\nMigration complete: ${migrated} succeeded, ${failed} skipped (left NULL)`
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/components/address.tsx
+++ b/src/components/address.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import Link from "next/link";
 import { useBreakpoint } from "~/hooks/use-media-query";
 import { useENS } from "~/lib/sarafu/resolver";
@@ -12,28 +13,33 @@ interface IAddressProps {
   forceTruncate?: boolean;
   disableENS?: boolean;
   href?: string;
+
   /** Render as span instead of link (use when nested inside another link) */
   asSpan?: boolean;
-  /** Where to link: "profile" (internal /users page, default) or "explorer" (CeloScan) */
-  linkTo?: "profile" | "explorer";
+
+  /** Where to link: "profile" (internal /users page, default), "explorer" (CeloScan), or "none" */
+  linkTo?: "profile" | "explorer" | "none";
 }
 
 function Address(props: IAddressProps) {
   const md = useBreakpoint("lg");
+
   const address =
     (md.isBelowLg && props.truncate) || props.forceTruncate
       ? truncateEthAddress(props.address)
       : props.address;
+
   const { data: ens } = useENS({
     address: props.address as `0x${string}`,
     disabled: props.disableENS,
   });
 
-  const displayText =
-    ens?.name && !Boolean(props.disableENS) ? ens?.name : address;
+  const displayText = ens?.name && !props.disableENS ? ens.name : address;
 
-  if (props.asSpan) {
-    return <span className={props?.className}>{displayText}</span>;
+  const shouldRenderSpan = props.asSpan || props.linkTo === "none";
+
+  if (shouldRenderSpan) {
+    return <span className={props.className}>{displayText}</span>;
   }
 
   const defaultHref =
@@ -42,6 +48,7 @@ function Address(props: IAddressProps) {
       : `/users/${props.address}`;
 
   const href = props.href || defaultHref;
+
   const isExternal =
     props.linkTo === "explorer" || props.href?.startsWith("http");
 
@@ -49,7 +56,7 @@ function Address(props: IAddressProps) {
     <Link
       target={isExternal ? "_blank" : undefined}
       rel={isExternal ? "noopener noreferrer" : undefined}
-      className={props?.className}
+      className={props.className}
       href={href}
     >
       {displayText}

--- a/src/components/dialogs/send-dialog.tsx
+++ b/src/components/dialogs/send-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Send } from "lucide-react";
+import { ChevronDown, CornerDownLeft, Lock, Send, Users } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -35,6 +35,7 @@ import {
 import { Input } from "../ui/input";
 import { VoucherSelectItem } from "../voucher/select-voucher-item";
 import { VoucherSelectField } from "../voucher/voucher-select-field";
+
 const FormSchema = z.object({
   voucherAddress: z.custom<`0x${string}`>(isAddress, "Invalid voucher address"),
   amount: z.coerce.number().positive(),
@@ -43,14 +44,19 @@ const FormSchema = z.object({
     "Invalid recipient address"
   ),
 });
+
 interface SendDialogProps {
   voucherAddress?: `0x${string}`;
+  ownerAddress?: `0x${string}`;
+  redeemMode?: boolean;
   button?: React.ReactNode;
 }
 
 export const SendForm = (props: {
   voucherAddress?: `0x${string}`;
   recipientAddress?: `0x${string}`;
+  ownerAddress?: `0x${string}`;
+  redeemMode?: boolean;
   onSuccess?: () => void;
   className?: string;
 }) => {
@@ -58,13 +64,23 @@ export const SendForm = (props: {
   const utils = trpc.useUtils();
   const { submitReferral, getReferralTag } = useDivviReferral();
   const [showAllVouchers, setShowAllVouchers] = useState(false);
+  const [recipientKey, setRecipientKey] = useState(0);
+  const [showContacts, setShowContacts] = useState(false);
+  const [selectedContact, setSelectedContact] = useState<{ name: string; address: string } | null>(null);
+
   const { data: allVouchers } = trpc.voucher.list.useQuery({}, {});
   const { data: myVouchers } = trpc.me.vouchers.useQuery(undefined, {
     enabled: Boolean(auth?.session?.address),
   });
+  const { data: events } = trpc.me.events.useQuery(
+    { limit: 50 },
+    { enabled: Boolean(auth?.session?.address) }
+  );
+
   const defaultVoucherAddress =
     props.voucherAddress ??
     (auth?.user?.default_voucher as `0x${string}` | undefined);
+
   const form = useForm<
     z.input<typeof FormSchema>,
     unknown,
@@ -75,12 +91,36 @@ export const SendForm = (props: {
     reValidateMode: "onChange",
     defaultValues: {
       voucherAddress: defaultVoucherAddress,
-      recipientAddress: props.recipientAddress,
+      recipientAddress: props.redeemMode
+        ? props.ownerAddress
+        : props.recipientAddress,
     },
   });
+
   const defaultVoucher = allVouchers?.find(
     (v) => v.voucher_address === defaultVoucherAddress
   );
+
+  // Derive recent send recipients from transaction history
+  const contacts = React.useMemo(() => {
+    if (!events?.events || !auth?.session?.address) return [];
+    const currentAddress = auth.session.address.toLowerCase();
+    const seen = new Set<string>();
+    return events.events
+      .filter(
+        (tx) =>
+          tx.event_type?.toLowerCase() === "token_transfer" &&
+          typeof tx.from_address === "string" &&
+          tx.from_address.toLowerCase() === currentAddress
+      )
+      .map((tx) => tx.to_address as string)
+      .filter((addr: string) => addr && !seen.has(addr) && (seen.add(addr), true))
+      .slice(0, 5)
+      .map((addr: string) => ({
+        name: `${addr.slice(0, 6)}…${addr.slice(-4)}`,
+        address: addr,
+      }));
+  }, [events, auth?.session?.address]);
 
   const isValid = form.formState.isValid;
   const voucherAddress = form.watch("voucherAddress");
@@ -89,6 +129,16 @@ export const SendForm = (props: {
   const debouncedAmount = useDebounce(amount, 500);
   const debouncedRecipientAddress = useDebounce(recipientAddress, 500);
   const { data: voucherDetails } = useVoucherDetails(voucherAddress);
+
+  const currentVoucher = React.useMemo(
+    () => allVouchers?.find((v) => v.voucher_address === voucherAddress),
+    [allVouchers, voucherAddress]
+  );
+
+  // Use explicit ownerAddress prop if provided, otherwise derive from the selected voucher
+  const effectiveOwnerAddress = (props.ownerAddress ??
+    (currentVoucher?.sink_address as `0x${string}` | undefined));
+
   const simulateContract = useSimulateContract({
     address: voucherAddress,
     abi: erc20Abi,
@@ -119,6 +169,7 @@ export const SendForm = (props: {
     address: account.address,
     token: voucherAddress,
   });
+
   const handleSubmit = () => {
     if (simulateContract.data?.request) {
       void writeContractAsync?.(simulateContract.data.request)
@@ -136,7 +187,6 @@ export const SendForm = (props: {
           }
         })
         .then((txHash) => {
-          // Submit Divvi referral for transaction attribution (non-blocking)
           if (txHash) {
             void submitReferral(txHash);
           }
@@ -166,59 +216,199 @@ export const SendForm = (props: {
       return myVouchers ?? [];
     }
   }, [allVouchers, showAllVouchers, defaultVoucher, myVouchers]);
+
   if (hash) {
     return <TransactionStatus hash={hash} />;
   }
   if (isPending) {
     return <TransactionStatus />;
   }
+
   return (
     <Form {...form}>
       <form
         onSubmit={(event) => void form.handleSubmit(handleSubmit)(event)}
         className={cn("space-y-8", props.className)}
       >
-        <div className="flex flex-col gap-2">
-          <VoucherSelectField
-            form={form}
-            name="voucherAddress"
-            label="Voucher"
-            placeholder="Select voucher"
-            className="flex-grow"
-            renderItem={(x) => (
-              <VoucherSelectItem
-                voucher={{
-                  address: x.voucher_address as `0x${string}`,
-                  name: x.voucher_name,
-                  symbol: x.symbol,
-                  icon: x.icon_url,
-                }}
-              />
-            )}
-            renderSelectedItem={(x) => (
-              <VoucherSelectItem
-                showBalance={false}
-                voucher={{
-                  address: x.voucher_address as `0x${string}`,
-                  name: x.voucher_name,
-                  symbol: x.symbol,
-                  icon: x.icon_url,
-                }}
-              />
-            )}
-            items={vouchers}
-          />
-          <div className="flex  justify-end items-center ">
-            <Checkbox
-              checked={showAllVouchers}
-              onCheckedChange={() => setShowAllVouchers((v) => !v)}
-            />
-            <span className="ml-2">Show all</span>
+        {/* ── Voucher section ── */}
+        {props.redeemMode ? (
+          <div className="flex flex-col gap-1.5">
+            <p className="text-sm font-medium leading-none">Voucher</p>
+            <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2.5 text-sm">
+              {defaultVoucher?.icon_url && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={defaultVoucher.icon_url}
+                  alt=""
+                  className="h-5 w-5 shrink-0 rounded-full object-cover"
+                />
+              )}
+              <span className="font-medium">
+                {defaultVoucher?.voucher_name ?? "Voucher"}
+              </span>
+              {defaultVoucher?.symbol && (
+                <span className="text-muted-foreground">
+                  {defaultVoucher.symbol}
+                </span>
+              )}
+              <Lock className="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <VoucherSelectField
+              form={form}
+              name="voucherAddress"
+              label="Voucher"
+              placeholder="Select voucher"
+              className="flex-grow"
+              renderItem={(x) => (
+                <VoucherSelectItem
+                  voucher={{
+                    address: x.voucher_address as `0x${string}`,
+                    name: x.voucher_name,
+                    symbol: x.symbol,
+                    icon: x.icon_url,
+                  }}
+                />
+              )}
+              renderSelectedItem={(x) => (
+                <VoucherSelectItem
+                  showBalance={false}
+                  voucher={{
+                    address: x.voucher_address as `0x${string}`,
+                    name: x.voucher_name,
+                    symbol: x.symbol,
+                    icon: x.icon_url,
+                  }}
+                />
+              )}
+              items={vouchers}
+            />
+            <div className="flex justify-end items-center">
+              <Checkbox
+                checked={showAllVouchers}
+                onCheckedChange={() => setShowAllVouchers((v) => !v)}
+              />
+              <span className="ml-2">Show all</span>
+            </div>
+          </div>
+        )}
 
-        <AddressField form={form} label="Recipient" name="recipientAddress" />
+        {/* ── Recipient section ── */}
+        {props.redeemMode ? (
+          <div className="flex flex-col gap-1.5">
+            <p className="text-sm font-medium leading-none">Recipient</p>
+            <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+              <Lock className="h-3 w-3 shrink-0" />
+              <span className="truncate">
+                {effectiveOwnerAddress
+                  ? `${effectiveOwnerAddress.slice(0, 6)}…${effectiveOwnerAddress.slice(-4)}`
+                  : "Voucher owner"}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            <AddressField
+              key={recipientKey}
+              form={form}
+              label="Recipient"
+              name="recipientAddress"
+              className="space-y-4"
+              labelAction={
+                effectiveOwnerAddress ? (
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 text-[13px] font-normal text-primary hover:underline hover:underline-offset-2"
+                    onClick={() => {
+                      form.setValue(
+                        "recipientAddress",
+                        effectiveOwnerAddress,
+                        { shouldValidate: true }
+                      );
+                      setRecipientKey((k) => k + 1);
+                      setSelectedContact(null);
+                    }}
+                  >
+                    <CornerDownLeft className="h-3 w-3 shrink-0" />
+                    Send to Voucher Owner (Redeem)
+                  </button>
+                ) : undefined
+              }
+            />
 
+            {/* Helper text: voucher owner or recent send recipient */}
+            {effectiveOwnerAddress &&
+            recipientAddress === effectiveOwnerAddress &&
+            currentVoucher ? (
+              <p className="mt-1 text-xs text-primary">
+                Sending {currentVoucher.symbol} to {currentVoucher.voucher_name}
+              </p>
+            ) : selectedContact &&
+              recipientAddress === selectedContact.address ? (
+              <p className="mt-1 text-xs text-primary">
+                Sending to {selectedContact.name}
+              </p>
+            ) : null}
+
+            {/* Contacts */}
+            {contacts.length > 0 && (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowContacts((v) => !v)}
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <Users className="h-3 w-3" />
+                  <span>Recent sends</span>
+                  <ChevronDown
+                    className={cn(
+                      "h-3 w-3 transition-transform duration-150",
+                      showContacts && "rotate-180"
+                    )}
+                  />
+                </button>
+                {showContacts && (
+                  <div className="mt-1.5 overflow-hidden rounded-md border bg-card shadow-sm">
+                    {contacts.map((contact) => (
+                      <button
+                        key={contact.address}
+                        type="button"
+                        onClick={() => {
+                          form.setValue(
+                            "recipientAddress",
+                            contact.address as `0x${string}`,
+                            { shouldValidate: true }
+                          );
+                          setRecipientKey((k) => k + 1);
+                          setShowContacts(false);
+                          setSelectedContact(contact);
+                        }}
+                        className="flex w-full items-center gap-3 border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                          {contact.name.charAt(0)}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium leading-none">
+                            {contact.name}
+                          </p>
+                          <p className="mt-0.5 text-xs text-muted-foreground">
+                            {contact.address.slice(0, 10)}…
+                            {contact.address.slice(-4)}
+                          </p>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* ── Amount ── */}
         <FormField
           control={form.control}
           name="amount"
@@ -226,7 +416,7 @@ export const SendForm = (props: {
             <FormItem>
               <FormLabel>Amount</FormLabel>
               <FormControl>
-                <div className="relative">
+                <div className="relative mt-1.5">
                   <Input
                     placeholder="Amount"
                     {...field}
@@ -254,12 +444,10 @@ export const SendForm = (props: {
                 shortMessage?: string;
                 message?: string;
               };
-              // Handle specific error cases
               if (error.message?.includes("insufficient funds"))
                 return "Insufficient funds to complete this transaction";
               if (error.message?.includes("gas required exceeds allowance"))
                 return "Transaction would exceed gas limits";
-              // Return shortMessage if available, otherwise fallback to a user-friendly message
               return (
                 error.shortMessage ??
                 "Unable to process transaction. Please verify your inputs and try again"
@@ -285,9 +473,14 @@ export const SendDialog = (props: SendDialogProps) => {
   return (
     <ResponsiveModal
       button={props.button ?? <Send className="m-1" />}
-      title="Send Voucher"
+      title={props.redeemMode ? "Redeem Voucher" : "Send Voucher"}
     >
-      <SendForm className="px-4 mt-4" voucherAddress={props.voucherAddress} />
+      <SendForm
+        className="px-4 mt-4"
+        voucherAddress={props.voucherAddress}
+        ownerAddress={props.ownerAddress}
+        redeemMode={props.redeemMode}
+      />
     </ResponsiveModal>
   );
 };

--- a/src/components/dialogs/send-dialog.tsx
+++ b/src/components/dialogs/send-dialog.tsx
@@ -13,11 +13,12 @@ import { erc20Abi, isAddress, parseUnits } from "viem";
 import { useAccount, useSimulateContract, useWriteContract } from "wagmi";
 import { ResponsiveModal } from "~/components/responsive-modal";
 import { useBalance } from "~/contracts/react";
+import { useAuth } from "~/hooks/use-auth";
 import { useDebounce } from "~/hooks/use-debounce";
 import { useDivviReferral } from "~/hooks/use-divvi-referral";
-import { useAuth } from "~/hooks/use-auth";
 import { trpc } from "~/lib/trpc";
 import { cn } from "~/lib/utils";
+import Address from "../address";
 import { AddressField } from "../forms/fields/address-field";
 import { Loading } from "../loading";
 import { useVoucherDetails } from "../pools/hooks";
@@ -41,7 +42,7 @@ const FormSchema = z.object({
   amount: z.coerce.number().positive(),
   recipientAddress: z.custom<`0x${string}`>(
     isAddress,
-    "Invalid recipient address"
+    "Invalid recipient address",
   ),
 });
 
@@ -66,7 +67,10 @@ export const SendForm = (props: {
   const [showAllVouchers, setShowAllVouchers] = useState(false);
   const [recipientKey, setRecipientKey] = useState(0);
   const [showContacts, setShowContacts] = useState(false);
-  const [selectedContact, setSelectedContact] = useState<{ name: string; address: string } | null>(null);
+  const [selectedContact, setSelectedContact] = useState<{
+    name: string;
+    address: string;
+  } | null>(null);
 
   const { data: allVouchers } = trpc.voucher.list.useQuery({}, {});
   const { data: myVouchers } = trpc.me.vouchers.useQuery(undefined, {
@@ -74,7 +78,7 @@ export const SendForm = (props: {
   });
   const { data: events } = trpc.me.events.useQuery(
     { limit: 50 },
-    { enabled: Boolean(auth?.session?.address) }
+    { enabled: Boolean(auth?.session?.address) },
   );
 
   const defaultVoucherAddress =
@@ -98,7 +102,7 @@ export const SendForm = (props: {
   });
 
   const defaultVoucher = allVouchers?.find(
-    (v) => v.voucher_address === defaultVoucherAddress
+    (v) => v.voucher_address === defaultVoucherAddress,
   );
 
   // Derive recent send recipients from transaction history
@@ -111,10 +115,12 @@ export const SendForm = (props: {
         (tx) =>
           tx.event_type?.toLowerCase() === "token_transfer" &&
           typeof tx.from_address === "string" &&
-          tx.from_address.toLowerCase() === currentAddress
+          tx.from_address.toLowerCase() === currentAddress,
       )
       .map((tx) => tx.to_address)
-      .filter((addr: string) => addr && !seen.has(addr) && (seen.add(addr), true))
+      .filter(
+        (addr: string) => addr && !seen.has(addr) && (seen.add(addr), true),
+      )
       .slice(0, 5)
       .map((addr: string) => ({
         name: `${addr.slice(0, 6)}…${addr.slice(-4)}`,
@@ -132,12 +138,13 @@ export const SendForm = (props: {
 
   const currentVoucher = React.useMemo(
     () => allVouchers?.find((v) => v.voucher_address === voucherAddress),
-    [allVouchers, voucherAddress]
+    [allVouchers, voucherAddress],
   );
 
   // Use explicit ownerAddress prop if provided, otherwise derive from the selected voucher
-  const effectiveOwnerAddress = (props.ownerAddress ??
-    (currentVoucher?.sink_address as `0x${string}` | undefined));
+  const effectiveOwnerAddress =
+    props.ownerAddress ??
+    (currentVoucher?.sink_address as `0x${string}` | undefined);
 
   const simulateContract = useSimulateContract({
     address: voucherAddress,
@@ -147,17 +154,17 @@ export const SendForm = (props: {
       debouncedRecipientAddress,
       parseUnits(
         debouncedAmount?.toString() ?? "",
-        voucherDetails?.decimals ?? 0
+        voucherDetails?.decimals ?? 0,
       ),
     ],
     dataSuffix: getReferralTag(),
     query: {
       enabled: Boolean(
         voucherDetails?.decimals &&
-          debouncedAmount &&
-          debouncedRecipientAddress &&
-          voucherAddress &&
-          isValid
+        debouncedAmount &&
+        debouncedRecipientAddress &&
+        voucherAddress &&
+        isValid,
       ),
     },
     gas: 350_000n,
@@ -205,7 +212,7 @@ export const SendForm = (props: {
       if (
         defaultVoucher &&
         !myVouchers?.find(
-          (v) => v.voucher_address === defaultVoucher.voucher_address
+          (v) => v.voucher_address === defaultVoucher.voucher_address,
         )
       ) {
         if (myVouchers) {
@@ -322,11 +329,9 @@ export const SendForm = (props: {
                     type="button"
                     className="flex items-center gap-1 text-[13px] font-normal text-primary hover:underline hover:underline-offset-2"
                     onClick={() => {
-                      form.setValue(
-                        "recipientAddress",
-                        effectiveOwnerAddress,
-                        { shouldValidate: true }
-                      );
+                      form.setValue("recipientAddress", effectiveOwnerAddress, {
+                        shouldValidate: true,
+                      });
                       setRecipientKey((k) => k + 1);
                       setSelectedContact(null);
                     }}
@@ -365,7 +370,7 @@ export const SendForm = (props: {
                   <ChevronDown
                     className={cn(
                       "h-3 w-3 transition-transform duration-150",
-                      showContacts && "rotate-180"
+                      showContacts && "rotate-180",
                     )}
                   />
                 </button>
@@ -379,7 +384,7 @@ export const SendForm = (props: {
                           form.setValue(
                             "recipientAddress",
                             contact.address as `0x${string}`,
-                            { shouldValidate: true }
+                            { shouldValidate: true },
                           );
                           setRecipientKey((k) => k + 1);
                           setShowContacts(false);
@@ -392,10 +397,15 @@ export const SendForm = (props: {
                         </div>
                         <div className="min-w-0 flex-1">
                           <p className="text-sm font-medium leading-none">
-                            {contact.name}
+                            <Address
+                              className="inline-block mr-1"
+                              address={contact.address}
+                              forceTruncate={true}
+                              linkTo="none"
+                            />
                           </p>
                           <p className="mt-0.5 text-xs text-muted-foreground">
-                            {contact.address.slice(0, 10)}…
+                            {contact.address.slice(0, 6)}…
                             {contact.address.slice(-4)}
                           </p>
                         </div>

--- a/src/components/dialogs/send-dialog.tsx
+++ b/src/components/dialogs/send-dialog.tsx
@@ -113,7 +113,7 @@ export const SendForm = (props: {
           typeof tx.from_address === "string" &&
           tx.from_address.toLowerCase() === currentAddress
       )
-      .map((tx) => tx.to_address as string)
+      .map((tx) => tx.to_address)
       .filter((addr: string) => addr && !seen.has(addr) && (seen.add(addr), true))
       .slice(0, 5)
       .map((addr: string) => ({

--- a/src/components/dialogs/send-dialog.tsx
+++ b/src/components/dialogs/send-dialog.tsx
@@ -144,7 +144,7 @@ export const SendForm = (props: {
   // Use explicit ownerAddress prop if provided, otherwise derive from the selected voucher
   const effectiveOwnerAddress =
     props.ownerAddress ??
-    (currentVoucher?.sink_address as `0x${string}` | undefined);
+    (currentVoucher?.redemption_address as `0x${string}` | undefined);
 
   const simulateContract = useSimulateContract({
     address: voucherAddress,

--- a/src/components/forms/fields/address-field.tsx
+++ b/src/components/forms/fields/address-field.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { type UseFormReturn } from "react-hook-form";
 import { isAddress } from "viem";
 import { normalize } from "viem/ens";
@@ -29,6 +29,8 @@ interface AddressFieldProps<Form extends UseFormReturn<any>> {
   description?: string;
   disabled?: boolean;
   label: string;
+  labelAction?: React.ReactNode;
+  className?: string;
 }
 
 export function AddressField<Form extends UseFormReturn<any>>(
@@ -145,10 +147,19 @@ export function AddressField<Form extends UseFormReturn<any>>(
       name={props.name}
       render={({ field }) => {
         return (
-          <FormItem>
-            <FormLabel>{props.label}</FormLabel>
+          <FormItem className={props.className}>
+            <FormLabel>
+              {props.labelAction ? (
+                <div className="flex items-center justify-between w-full">
+                  <span>{props.label}</span>
+                  {props.labelAction}
+                </div>
+              ) : (
+                props.label
+              )}
+            </FormLabel>
             <FormControl>
-              <div className="relative flex gap-2">
+              <div className="relative flex gap-2 mt-1.5">
                 <Input
                   containerClassName="flex-grow"
                   disabled={props.disabled}

--- a/src/components/voucher/forms/voucher-form.tsx
+++ b/src/components/voucher/forms/voucher-form.tsx
@@ -2,6 +2,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { isAddress } from "viem";
 import { useAccount } from "wagmi";
 import { z } from "zod";
 import { isPhoneNumber } from "~/utils/phone-number";
@@ -44,6 +45,13 @@ const formSchema = z.object({
     .optional()
     .refine((v) => !v || isPhoneNumber(v), {
       message: "Enter a valid phone number",
+    }),
+  redemptionAddress: z
+    .string()
+    .nullable()
+    .optional()
+    .refine((v): boolean => v == null || v === "" || isAddress(v), {
+      message: "Invalid address format",
     }),
 });
 
@@ -88,15 +96,22 @@ const VoucherForm = ({
       voucherUoa: metadata?.voucher_uoa,
       voucherValue: metadata?.voucher_value,
       phoneNumber: metadata?.phone_number ?? null,
+      redemptionAddress:
+        metadata?.redemption_address ?? auth?.account?.address ?? "",
     },
   });
 
   const handleSubmit = async (formData: VoucherFormValues) => {
+    // Empty string in the redemption-address input means "clear it".
+    const trimmedRedemption =
+      typeof formData.redemptionAddress === "string"
+        ? formData.redemptionAddress.trim()
+        : formData.redemptionAddress;
     const payload = {
       ...formData,
       phoneNumber: formData.phoneNumber?.trim() || null,
+      redemptionAddress: trimmedRedemption === "" ? null : trimmedRedemption,
     };
-
     if (metadata) {
       try {
         if (!voucherAddress) return;
@@ -193,6 +208,15 @@ const VoucherForm = ({
           name="phoneNumber"
           label="Contact Phone"
           description="Public — voucher holders will see this so they can reach you."
+          className="w-full"
+        />
+
+        <InputField
+          form={form}
+          name="redemptionAddress"
+          label="Redemption Address"
+          placeholder="0x..."
+          description="Wallet that receives this voucher when users redeem. Defaults to the on-chain contract owner. Leave empty to disable redeem."
           className="w-full"
         />
 

--- a/src/components/voucher/voucher-contract-functions.tsx
+++ b/src/components/voucher/voucher-contract-functions.tsx
@@ -133,13 +133,15 @@ export function BasicVoucherFunctions({
       </div>
     );
   }
-  const sinkAddress = voucher?.sink_address as `0x${string}` | undefined;
+  const redemptionAddress = voucher?.redemption_address as
+    | `0x${string}`
+    | undefined;
 
   return (
     <div className={cn(className, "flex m-1 gap-2 flex-wrap")}>
       <SendDialog
         voucherAddress={voucher_address as `0x${string}`}
-        ownerAddress={sinkAddress}
+        ownerAddress={redemptionAddress}
         button={
           <Button variant={"outline"}>
             <SendIcon className="mr-2 stroke-slate-700 h-3" />
@@ -147,10 +149,10 @@ export function BasicVoucherFunctions({
           </Button>
         }
       />
-      {sinkAddress && (
+      {redemptionAddress && (
         <SendDialog
           voucherAddress={voucher_address as `0x${string}`}
-          ownerAddress={sinkAddress}
+          ownerAddress={redemptionAddress}
           redeemMode={true}
           button={
             <Button variant={"default"}>

--- a/src/components/voucher/voucher-contract-functions.tsx
+++ b/src/components/voucher/voucher-contract-functions.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  CornerDownLeft,
   PlusIcon,
   SendIcon,
   UserIcon,
@@ -132,10 +133,13 @@ export function BasicVoucherFunctions({
       </div>
     );
   }
+  const sinkAddress = voucher?.sink_address as `0x${string}` | undefined;
+
   return (
     <div className={cn(className, "flex m-1 gap-2 flex-wrap")}>
       <SendDialog
         voucherAddress={voucher_address as `0x${string}`}
+        ownerAddress={sinkAddress}
         button={
           <Button variant={"outline"}>
             <SendIcon className="mr-2 stroke-slate-700 h-3" />
@@ -143,6 +147,19 @@ export function BasicVoucherFunctions({
           </Button>
         }
       />
+      {sinkAddress && (
+        <SendDialog
+          voucherAddress={voucher_address as `0x${string}`}
+          ownerAddress={sinkAddress}
+          redeemMode={true}
+          button={
+            <Button variant={"default"}>
+              <CornerDownLeft className="mr-2 h-4 w-4" />
+              Redeem
+            </Button>
+          }
+        />
+      )}
       {(isWriter || isOwner) && (
         <MintToDialog
           voucher_address={voucher_address as `0x${string}`}

--- a/src/server/api/models/voucher.ts
+++ b/src/server/api/models/voucher.ts
@@ -24,6 +24,7 @@ const VOUCHER_LIST_FIELDS = [
   "vouchers.created_at",
   "vouchers.voucher_value",
   "vouchers.sink_address",
+  "vouchers.redemption_address",
   "vouchers.symbol",
 ] as const;
 
@@ -244,6 +245,7 @@ export class VoucherModel {
         "voucher_uoa",
         "voucher_type",
         "sink_address",
+        "redemption_address",
         "voucher_email",
         "voucher_website",
         "geo",
@@ -366,6 +368,11 @@ export class VoucherModel {
         voucher_value: input.voucherValue,
         ...(input.phoneNumber !== undefined && {
           phone_number: input.phoneNumber,
+        }),
+        // Only touch redemption_address when the caller explicitly sent it
+        // (null clears it, a string sets it, omitted leaves it alone).
+        ...(input.redemptionAddress !== undefined && {
+          redemption_address: input.redemptionAddress,
         }),
       })
       .where("voucher_address", "=", input.voucherAddress)

--- a/src/server/api/routers/voucher.ts
+++ b/src/server/api/routers/voucher.ts
@@ -68,6 +68,11 @@ const updateVoucherInput = z.object({
   voucherUoa: z.string().optional(),
   voucherValue: z.coerce.number().min(0).optional(),
   phoneNumber: phoneInput,
+  redemptionAddress: z
+    .string()
+    .refine(isAddress, { message: "Invalid address format" })
+    .nullable()
+    .optional(),
 });
 export type UpdateVoucherInput = z.infer<typeof updateVoucherInput>;
 

--- a/src/server/db/graph-db.d.ts
+++ b/src/server/db/graph-db.d.ts
@@ -271,6 +271,7 @@ export interface Vouchers {
   internal: Generated<boolean | null>;
   location_name: string | null;
   radius: number | null;
+  redemption_address: string | null;
   sink_address: string;
   symbol: string;
   voucher_address: string;


### PR DESCRIPTION
Title:
  feat(send): redeem mode, voucher owner shortcut, and recent sends

  Body:
  ## Summary

  - **Redeem mode**: `SendForm` accepts a `redeemMode` prop that locks the voucher and recipient fields (showing the voucher's
  `sink_address` as a read-only recipient). Used by the Redeem button on the voucher detail page.
  - **Send to Voucher Owner shortcut**: In standard send mode, a "Send to Voucher Owner (Redeem)" link appears next to the Recipient
  label when a voucher with a `sink_address` is selected. Clicking it pre-fills the recipient field and shows helper text ("Sending
  RVFM to River Valley Farm").
  - **Recent sends dropdown**: Pulls the last 5 unique outgoing `token_transfer` recipients from `trpc.me.events` and surfaces them in
  a collapsible list below the recipient field. Selecting one pre-fills the address and shows the truncated address as confirmation
  text.
  - **`AddressField` updates**: Added `labelAction` and `className` props to support the label-row action button pattern.

  ## Notes
  - Recent sends shows truncated addresses (`0x1234…abcd`). ENS reverse resolution or an address book could enhance display names
  later.
  - `effectiveOwnerAddress` is derived from the selected voucher's `sink_address` when no explicit `ownerAddress` prop is passed — no
  additional API call needed.

  ## Test plan
  - [ ] Send dialog: select a voucher with a sink address → "Send to Voucher Owner (Redeem)" link appears, clicking it fills recipient
  field
  - [ ] Send dialog: recent sends dropdown appears if transaction history contains outgoing transfers
  - [ ] Voucher detail page: Redeem button opens dialog with locked voucher and recipient fields
  - [ ] Standard send flow unaffected

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

