### PR TITLE
feat(roles): add APPROVER role for reports and gas approvals

### DIFF
--- a/__tests__/utils/persmissions.test.ts
+++ b/__tests__/utils/persmissions.test.ts
@@ -7,6 +7,7 @@ describe("Permission Tests", () => {
   const superAdmin = { role: "SUPER_ADMIN" } as const;
   const admin = { role: "ADMIN" } as const;
   const staff = { role: "STAFF" } as const;
+  const approver = { role: "APPROVER" } as const;
   const user = { role: "USER" } as const;
 
   it("should allow SUPER_ADMIN and Owner to perform all actions ", () => {
@@ -37,6 +38,23 @@ describe("Permission Tests", () => {
 
     expect(permissions.Gas.APPROVE).toBe(true);
     expect(permissions.Vouchers.UPDATE).toBe(false);
+  });
+
+  it("should allow APPROVER to approve gas and reports only", () => {
+    const permissions = getPermissions(approver, false);
+
+    expect(permissions.Gas.APPROVE).toBe(true);
+    expect(permissions.Reports.APPROVE).toBe(true);
+
+    expect(permissions.Reports.REJECT).toBe(false);
+    expect(permissions.Reports.UPDATE).toBe(false);
+    expect(permissions.Reports.DELETE).toBe(false);
+    expect(permissions.Vouchers.UPDATE).toBe(false);
+    expect(permissions.Vouchers.DELETE).toBe(false);
+    expect(permissions.Users.UPDATE).toBe(false);
+    expect(permissions.Users.UPDATE_ROLE).toBe(false);
+    expect(permissions.Users.VIEW_PII).toBe(false);
+    expect(permissions.Products.UPDATE).toBe(false);
   });
 
   it("should allow OWNER to delete if isOwner is true", () => {

--- a/src/app/(main)/staff/page.tsx
+++ b/src/app/(main)/staff/page.tsx
@@ -28,7 +28,7 @@ const StaffPage = async () => {
 
   if (
     !Boolean(user) ||
-    !["STAFF", "ADMIN", "SUPER_ADMIN"].includes(user?.role ?? "")
+    !["STAFF", "ADMIN", "SUPER_ADMIN", "APPROVER"].includes(user?.role ?? "")
   ) {
     return redirect("/");
   }

--- a/src/server/api/routers/gas.ts
+++ b/src/server/api/routers/gas.ts
@@ -8,18 +8,29 @@ import {
 import { EthFaucet } from "~/contracts/eth-faucet";
 import { withWriterLock } from "~/contracts/writer";
 import { env } from "~/env";
-import { router, staffProcedure } from "~/server/api/trpc";
+import {
+  authenticatedProcedure,
+  router,
+  staffProcedure,
+} from "~/server/api/trpc";
 import { GasGiftStatus } from "~/server/enums";
 import { redis } from "~/utils/cache/kv";
+import { hasPermission } from "~/utils/permissions";
 
 export const gasRouter = router({
-  get: staffProcedure
+  get: authenticatedProcedure
     .input(
       z.object({
         address: z.string().refine(isAddress, { message: "Invalid address" }),
       })
     )
     .query(async ({ ctx, input }) => {
+      if (!hasPermission(ctx.session.user, false, "Gas", "APPROVE")) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to view gas request status",
+        });
+      }
       const account = await ctx.graphDB
         .selectFrom("accounts")
         .where("blockchain_address", "=", input.address)
@@ -39,13 +50,19 @@ export const gasRouter = router({
       }
       return account.gas_gift_status as keyof typeof GasGiftStatus;
     }),
-  approve: staffProcedure
+  approve: authenticatedProcedure
     .input(
       z.object({
         address: z.string().refine(isAddress, { message: "Invalid address" }),
       })
     )
     .mutation(async ({ ctx, input }) => {
+      if (!hasPermission(ctx.session.user, false, "Gas", "APPROVE")) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have permission to approve gas requests",
+        });
+      }
       const approver_id = ctx.session.user.account_id;
       if (!approver_id) {
         throw new TRPCError({

--- a/src/server/enums.ts
+++ b/src/server/enums.ts
@@ -11,6 +11,7 @@ export const AccountRoleType = {
   SUPER_ADMIN: "SUPER_ADMIN",
   ADMIN: "ADMIN",
   STAFF: "STAFF",
+  APPROVER: "APPROVER",
   USER: "USER",
 } as const;
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,8 +1,14 @@
 import { AccountRoleType } from "~/server/enums";
-type Role = "SUPER_ADMIN" | "ADMIN" | "OWNER" | "STAFF" | "USER";
+type Role =
+  | "SUPER_ADMIN"
+  | "ADMIN"
+  | "OWNER"
+  | "STAFF"
+  | "APPROVER"
+  | "USER";
 
 interface User {
-  role: "SUPER_ADMIN" | "ADMIN" | "STAFF" | "USER";
+  role: "SUPER_ADMIN" | "ADMIN" | "STAFF" | "APPROVER" | "USER";
 }
 
 export const permissions = {
@@ -29,7 +35,7 @@ export const permissions = {
     CREATE: ["SUPER_ADMIN", "ADMIN", "OWNER", "STAFF", "USER"],
     UPDATE: ["SUPER_ADMIN", "ADMIN", "OWNER", "STAFF"],
     DELETE: ["SUPER_ADMIN", "OWNER"],
-    APPROVE: ["SUPER_ADMIN", "ADMIN", "STAFF"],
+    APPROVE: ["SUPER_ADMIN", "ADMIN", "STAFF", "APPROVER"],
     REJECT: ["SUPER_ADMIN", "ADMIN", "STAFF"],
     SUBMIT: ["OWNER"],
     VIEW: ["SUPER_ADMIN", "ADMIN", "OWNER", "STAFF"],
@@ -38,7 +44,7 @@ export const permissions = {
     CREATE: ["SUPER_ADMIN"],
   },
   Gas: {
-    APPROVE: ["SUPER_ADMIN", "ADMIN", "STAFF"],
+    APPROVE: ["SUPER_ADMIN", "ADMIN", "STAFF", "APPROVER"],
   },
   Contract: {
     UPDATE: ["OWNER"],
@@ -112,6 +118,10 @@ export const isAdmin = (user?: User) => {
 };
 export const isStaff = (user?: User) => {
   return user?.role === AccountRoleType.STAFF;
+};
+
+export const isApprover = (user?: User) => {
+  return user?.role === AccountRoleType.APPROVER;
 };
 
 export const isSuperAdmin = (user?: User) => {


### PR DESCRIPTION
## Summary
- Adds a new `APPROVER` account role whose only permissions are `Reports.APPROVE` and `Gas.APPROVE`.
- Refactors `gas.get` and `gas.approve` from `staffProcedure` to `authenticatedProcedure` + `hasPermission` so APPROVER can use them without inheriting other staff-only routes (e.g. `gas.reject`, `staff.createWallet`).
- Allows APPROVER to reach `/staff` (UI surface for gas approvals) and adds a permissions test covering the new role.

## Test plan
- [x] \`pnpm check-types\`
- [x] \`pnpm test\` (377 passed)
- [ ] Manual: assign a user the APPROVER role and verify they can approve a report and a gas request, but cannot reject, update vouchers, or create wallets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)