### PR TITLE
fix: update About navigation link

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -90,7 +90,7 @@ const data = {
   navDocumentation: [
     {
       title: "About",
-      url: "https://docs.grassecon.org/",
+      url: "/about",
       icon: Info,
     },
     {

--- a/src/config/site.tsx
+++ b/src/config/site.tsx
@@ -150,7 +150,7 @@ const siteConfig: {
         {
           icon: <BookOpen size={18} />,
           title: "About",
-          href: "https://docs.grassecon.org/",
+          href: "/about",
           description: "Learn about Grassroots Economics",
         },
         {


### PR DESCRIPTION
## Summary
- Point About menu items to the internal /about route.

## Verification
- Could not complete `pnpm run check-types` locally because `node_modules` is missing `libphonenumber-js`, and downloading the missing dependency was not approved.
- The PR diff is limited to two navigation URL changes.