### PR TITLE
fix(onramp): refresh verified phone before BuyDialog handoff

### DIFF
--- a/src/components/dialogs/buy-dialog.tsx
+++ b/src/components/dialogs/buy-dialog.tsx
@@ -156,6 +156,16 @@ function BuyFlow({
   const [amount, setAmount] = useState<number>(0);
   const [transactionCode, setTransactionCode] = useState<string | null>(null);
 
+  // The me.get cache can land after BuyFlow mounts (e.g. when the verify
+  // dialog hands off before its invalidation resolves). Adopt the verified
+  // phone when it arrives so we don't strand the user on a stale "phone"
+  // step or show an empty PhoneRow.
+  useEffect(() => {
+    if (!verifiedPhone) return;
+    setPhoneNumber((current) => (current ? current : verifiedPhone));
+    setStep((current) => (current === "phone" ? "amount" : current));
+  }, [verifiedPhone]);
+
   const ratesQuery = trpc.onramp.getRates.useQuery(undefined, {
     refetchOnWindowFocus: false,
   });

--- a/src/components/dialogs/verify-phone-dialog.tsx
+++ b/src/components/dialogs/verify-phone-dialog.tsx
@@ -130,11 +130,18 @@ function VerifyFlow({
             setStep("phone");
           }}
           onSubmit={async (code) => {
-            // Resolve as soon as the server confirms; CodeStep then drives
-            // its own "verified" success display. Cache invalidation runs
-            // in the background and doesn't block the visual confirmation.
             await verifyMutation.mutateAsync({ phone, code });
-            void utils.invalidate();
+            // Await the me.* refetch so consumers reading auth.user (e.g. the
+            // BuyDialog that opens immediately after onVerified) see the
+            // freshly verified phone instead of the pre-verification snapshot.
+            // Swallow refetch errors: the OTP is already consumed, so a
+            // transient network failure here must not surface as "Invalid
+            // code" — BuyFlow's effect adopts the phone once the cache lands.
+            try {
+              await utils.me.invalidate();
+            } catch {
+              // ignore — best-effort cache refresh
+            }
           }}
           onCompleted={() => onVerified(phone)}
         />


### PR DESCRIPTION
## Summary
- After verifying a phone via the onramp flow, BuyDialog was reading a stale `auth.user` snapshot because the cache invalidation in VerifyPhoneDialog was fire-and-forget, leaving users stranded on the "phone" step or staring at an empty phone row.
- Await the targeted `utils.me.invalidate()` in VerifyPhoneDialog so the handoff to BuyDialog reads fresh data; refetch errors are swallowed so they can't be misreported as "Invalid code" by CodeStep (the OTP has already been consumed).
- Add a defensive \`useEffect\` in \`BuyFlow\` that adopts a late-arriving \`verifiedPhone\` — fills \`phoneNumber\` and advances from "phone" to "amount" — so the same race can't recur from any other entry point.

## Test plan
- [ ] Onramp flow as a user with no verified phone: verify → BuyDialog opens directly on the "amount" step with the verified number prefilled.
- [ ] OTP type check / existing OTP tests still pass.
- [ ] Simulate a slow/failed \`me.get\` refetch after a valid OTP: the "Verified" confirmation still shows; user is not falsely told the code is invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)