### PR TITLE
perf(build): drop unused generateStaticParams to cut build time ~3.5min

### DIFF
--- a/src/app/(main)/pools/[address]/page.tsx
+++ b/src/app/(main)/pools/[address]/page.tsx
@@ -1,23 +1,10 @@
 import type { Metadata } from "next";
 import { getAddress } from "viem";
-import {
-  getContractIndex,
-  getSwapPool,
-} from "~/components/pools/contract-functions";
+import { getSwapPool } from "~/components/pools/contract-functions";
 import { publicClient } from "~/config/viem.config.server";
-import { env } from "~/env";
 import { caller } from "~/server/api/routers/_app";
 import { PoolClientPage } from "./pool-client-page";
 
-export async function generateStaticParams() {
-  const data = await getContractIndex(
-    publicClient,
-    env.NEXT_PUBLIC_SWAP_POOL_INDEX_ADDRESS
-  );
-  return data.contractAddresses.map((address) => ({
-    address: address,
-  }));
-}
 type Props = {
   params: Promise<{ address: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/src/app/(main)/vouchers/[address]/page.tsx
+++ b/src/app/(main)/vouchers/[address]/page.tsx
@@ -5,17 +5,6 @@ import VoucherPageClient from "~/components/voucher/voucher-page";
 import { publicClient } from "~/config/viem.config.server";
 import { getTokenDetails } from "~/server/api/models/token";
 import { caller } from "~/server/api/routers/_app";
-import { graphDB } from "~/server/db";
-
-export async function generateStaticParams() {
-  const vouchers = await graphDB
-    .selectFrom("vouchers")
-    .select("voucher_address")
-    .execute();
-  return vouchers.map((v) => ({
-    address: v.voucher_address,
-  }));
-}
 
 type Props = {
   params: Promise<{ address: string }>;

--- a/src/components/dialogs/buy-dialog.tsx
+++ b/src/components/dialogs/buy-dialog.tsx
@@ -159,10 +159,14 @@ function BuyFlow({
   // The me.get cache can land after BuyFlow mounts (e.g. when the verify
   // dialog hands off before its invalidation resolves). Adopt the verified
   // phone when it arrives so we don't strand the user on a stale "phone"
-  // step or show an empty PhoneRow.
+  // step or show an empty PhoneRow. This is a legitimate "sync with
+  // external data" effect — the setState calls are guarded so they run
+  // at most once per verifiedPhone change.
   useEffect(() => {
     if (!verifiedPhone) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPhoneNumber((current) => (current ? current : verifiedPhone));
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setStep((current) => (current === "phone" ? "amount" : current));
   }, [verifiedPhone]);
 

--- a/src/components/voucher/forms/create-offer-voucher-wizard/steps/step-3-voucher.tsx
+++ b/src/components/voucher/forms/create-offer-voucher-wizard/steps/step-3-voucher.tsx
@@ -10,7 +10,7 @@ import {
   Ticket,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { DateField } from "~/components/forms/fields/date-field";
 import { InputField } from "~/components/forms/fields/input-field";
 import { MapField } from "~/components/forms/fields/map-field";
@@ -95,8 +95,11 @@ export function Step3Voucher({ onComplete, onBack }: Step3Props) {
     },
   });
 
-  const watchedVoucherType = form.watch("voucherType");
-  const watchedName = form.watch("name");
+  const watchedVoucherType = useWatch({
+    control: form.control,
+    name: "voucherType",
+  });
+  const watchedName = useWatch({ control: form.control, name: "name" });
 
   // Auto-fill fields from user profile
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Removed `generateStaticParams` from `/vouchers/[address]` and `/pools/[address]`. Both routes are force-marked dynamic at runtime (the tRPC `caller` reads cookies via `auth()`), so the ~2700 prerendered HTML files were never served — confirmed in prod with `cache-control: private, no-store` and `x-vercel-cache: MISS`.
- Expected build impact: the "Generating static pages" phase drops from 3.5min/2701 pages to a handful, roughly halving total build time. SEO is unchanged because `generateMetadata` still runs per request.
- Drive-by lint fixes to clear the pre-push hook on code recently merged via #432/#440: switched `form.watch()` → `useWatch()` in step-3-voucher, and scope-disabled `react-hooks/set-state-in-effect` for the legitimate verified-phone adoption effect in `buy-dialog`.

## Test plan
- [ ] Inspect next Vercel build log: "Generating static pages" should report ≤ ~30 pages and complete in seconds, not minutes.
- [ ] Hit `/vouchers/<address>` and `/pools/<address>` on the preview deploy and confirm pages render + OG metadata is correct.