### PR TITLE
feat(auth): unify nav into single Sign In dialog (paper + external wallets)

### DIFF
--- a/src/components/auth/sign-in-dialog.tsx
+++ b/src/components/auth/sign-in-dialog.tsx
@@ -119,7 +119,7 @@ function OptionButton({
     <button
       type="button"
       onClick={onClick}
-      className="group flex items-center gap-4 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-accent focus:outline-hidden focus:ring-2 focus:ring-ring"
+      className="group flex items-center gap-4 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-hidden focus:ring-2 focus:ring-ring"
     >
       <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
         {icon}

--- a/src/components/auth/sign-in-dialog.tsx
+++ b/src/components/auth/sign-in-dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronRight, QrCode, Sparkles, Wallet } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, type ReactNode } from "react";
+import { toast } from "sonner";
+import { useConnectors } from "wagmi";
+import { signInWithPaperWallet } from "~/lib/auth/paper-login";
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+import { ResponsiveModal } from "../responsive-modal";
+
+interface SignInDialogProps {
+  triggerClassName?: string;
+}
+
+export function SignInDialog({ triggerClassName }: SignInDialogProps) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const connectors = useConnectors();
+  const { openConnectModal } = useConnectModal();
+  const router = useRouter();
+
+  const handleConnectWallet = () => {
+    setOpen(false);
+    openConnectModal?.();
+  };
+
+  const handlePaperLogin = () => {
+    setOpen(false);
+    // Defer to next tick so the modal finishes closing before any
+    // downstream scan / password modal is opened.
+    setTimeout(() => {
+      void (async () => {
+        try {
+          await signInWithPaperWallet({
+            queryClient,
+            connectors,
+            openConnectModal,
+          });
+        } catch (err) {
+          const message =
+            err instanceof Error
+              ? err.message
+              : "Failed to connect with Paper Wallet";
+          if (!message.toLowerCase().includes("cancel")) {
+            console.error("Failed to connect with Paper Wallet", err);
+            toast.error(message);
+          }
+        }
+      })();
+    }, 0);
+  };
+
+  const handleCreatePaperWallet = () => {
+    setOpen(false);
+    router.push("/paper/create");
+  };
+
+  return (
+    <ResponsiveModal
+      open={open}
+      onOpenChange={setOpen}
+      title="Sign in to Sarafu Network"
+      description="Choose how you'd like to access your account."
+      button={
+        <Button
+          variant="default"
+          size="sm"
+          className={cn(
+            "rounded-full whitespace-nowrap border border-primary bg-primary text-primary-foreground hover:bg-primary/90",
+            triggerClassName
+          )}
+        >
+          Sign In
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3 pt-2 pb-2 px-1">
+        <OptionButton
+          icon={<Wallet className="size-5" />}
+          title="Connect Wallet"
+          description="Use MetaMask, Rabby, WalletConnect or another wallet."
+          onClick={handleConnectWallet}
+        />
+        <OptionButton
+          icon={<QrCode className="size-5" />}
+          title="Sign in with Paper Wallet"
+          description="Scan or upload a paper wallet QR you've already saved."
+          onClick={handlePaperLogin}
+        />
+        <OptionButton
+          icon={<Sparkles className="size-5" />}
+          title="Create a Paper Wallet"
+          description="New here? Generate a paper wallet to back up offline."
+          onClick={handleCreatePaperWallet}
+        />
+      </div>
+    </ResponsiveModal>
+  );
+}
+
+interface OptionButtonProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+}
+
+function OptionButton({
+  icon,
+  title,
+  description,
+  onClick,
+}: OptionButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-center gap-4 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-accent focus:outline-hidden focus:ring-2 focus:ring-ring"
+    >
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        {icon}
+      </div>
+      <div className="flex-1">
+        <div className="font-semibold leading-none">{title}</div>
+        <div className="mt-1 text-sm text-muted-foreground">{description}</div>
+      </div>
+      <ChevronRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+    </button>
+  );
+}

--- a/src/components/landing/CallToAction.tsx
+++ b/src/components/landing/CallToAction.tsx
@@ -3,7 +3,7 @@ import { Button } from "~/components/ui/button";
 
 export function CallToAction() {
   return (
-    <section className="bg-accent/90 text-primary py-8">
+    <section className="bg-button/90 text-primary py-8">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto text-center mb-8">
           <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold mb-6">

--- a/src/components/landing/CommunityImpact.tsx
+++ b/src/components/landing/CommunityImpact.tsx
@@ -6,7 +6,7 @@ export function CommunityImpact() {
     <section id="impact" className="py-16">
       <div className="mx-auto px-4">
         {/* Enhanced Testimonial with Real Image */}
-        <div className="bg-accent/50 rounded-2xl overflow-hidden max-w-6xl mx-auto">
+        <div className="bg-button/50 rounded-2xl overflow-hidden max-w-6xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
             {/* Image Column */}
             <div className="aspect-square lg:aspect-auto relative">

--- a/src/components/layout/user-nav.tsx
+++ b/src/components/layout/user-nav.tsx
@@ -1,18 +1,12 @@
 "use client";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { useQueryClient } from "@tanstack/react-query";
-import { connect, disconnect, getAccount, signMessage } from "@wagmi/core";
-import { useState } from "react";
-import { useBalance, useConnectors, useDisconnect } from "wagmi";
-import { createSiweAdapter } from "~/config/siwe";
-import { config } from "~/config/wagmi.config.client";
+import { useBalance, useDisconnect } from "wagmi";
 import { useAuth } from "~/hooks/use-auth";
 import { truncateEthAddress } from "~/utils/dmr-helpers";
 import { Button } from "../ui/button";
 
 import clsx from "clsx";
 import { Copy, Fuel, LogOut, Shield, User } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useBreakpoint } from "~/hooks/use-media-query";
@@ -20,8 +14,8 @@ import { GasGiftStatus } from "~/server/enums";
 import { toUserUnitsString } from "~/utils/units/token";
 import Address from "../address";
 import Identicon from "../identicon";
-import { Loading } from "../loading";
 import { Badge } from "../ui/badge";
+import { SignInDialog } from "../auth/sign-in-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,10 +27,7 @@ import {
 import { gasBadgeVariant } from "../users/staff-gas-status";
 export function UserNav() {
   const auth = useAuth();
-  const queryClient = useQueryClient();
   const isMd = useBreakpoint("md");
-  const [isPaperLoginPending, setIsPaperLoginPending] = useState(false);
-  const connectors = useConnectors();
   const { disconnectAsync } = useDisconnect();
   const router = useRouter();
   const user_address = auth?.session?.address;
@@ -65,94 +56,10 @@ export function UserNav() {
         toast.error(err.message);
       });
   };
-  const handlePaperLogin = async (openConnectModal?: () => void) => {
-    const paperConnector = connectors.find(
-      (connector) => connector.id === "paperConnector"
-    );
-    setIsPaperLoginPending(true);
-    try {
-      if (paperConnector) {
-        let accountAddress: `0x${string}` | undefined;
-        let chainId: number | undefined;
-        const activeAccount = getAccount(config);
-
-        if (activeAccount.status === "connected") {
-          if (activeAccount.connector?.id !== paperConnector.id) {
-            await disconnect(config);
-            const connection = await connect(config, {
-              connector: paperConnector,
-            });
-            const firstAccount = connection.accounts[0] as
-              | `0x${string}`
-              | { address: `0x${string}` }
-              | undefined;
-            accountAddress =
-              typeof firstAccount === "string"
-                ? firstAccount
-                : firstAccount?.address;
-            chainId = connection.chainId;
-          } else {
-            accountAddress = activeAccount.address;
-            chainId = activeAccount.chainId;
-          }
-        } else {
-          const connection = await connect(config, { connector: paperConnector });
-          const firstAccount = connection.accounts[0] as
-            | `0x${string}`
-            | { address: `0x${string}` }
-            | undefined;
-          accountAddress =
-            typeof firstAccount === "string"
-              ? firstAccount
-              : firstAccount?.address;
-          chainId = connection.chainId;
-        }
-
-        if (!accountAddress || !chainId) {
-          throw new Error("Paper Wallet connected but no account was found");
-        }
-
-        const siweAdapter = createSiweAdapter(queryClient);
-        const nonce = await siweAdapter.getNonce();
-        const message = siweAdapter.createMessage({
-          address: accountAddress,
-          chainId,
-          nonce,
-        });
-
-        const signature = await signMessage(config, { message });
-
-        const isVerified = await siweAdapter.verify({ message, signature });
-        if (!isVerified) {
-          throw new Error("Authentication failed");
-        }
-        return;
-      }
-      openConnectModal?.();
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : "Failed to connect with Paper Wallet";
-      if (!message.toLowerCase().includes("cancel")) {
-        console.error("Failed to connect with Paper Wallet", err);
-        toast.error(message);
-      }
-    } finally {
-      setIsPaperLoginPending(false);
-    }
-  };
   return (
     <div className="flex items-center justify-end space-x-2 font-family-poppins">
       <ConnectButton.Custom>
-        {({
-          chain,
-          openChainModal,
-          openConnectModal,
-          authenticationStatus,
-          connectModalOpen,
-          mounted,
-        }) => {
+        {({ chain, openChainModal, mounted }) => {
           return (
             <div
               {...(!mounted && {
@@ -169,43 +76,7 @@ export function UserNav() {
                 if (!mounted || !auth?.account || !chain) {
                   return (
                     <div className="flex w-full items-center justify-end gap-1 sm:gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="rounded-full whitespace-nowrap"
-                        disabled={
-                          connectModalOpen ||
-                          authenticationStatus === "loading" ||
-                          isPaperLoginPending
-                        }
-                        onClick={() => void handlePaperLogin(openConnectModal)}
-                      >
-                        {isPaperLoginPending ? <Loading /> : "Login"}
-                      </Button>
-                      <Button
-                        variant="default"
-                        size="sm"
-                        className="rounded-full whitespace-nowrap border border-primary bg-primary text-primary-foreground hover:bg-primary/90"
-                        asChild
-                      >
-                        <Link href="/paper/create">Sign-up</Link>
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        disabled={
-                          connectModalOpen ||
-                          authenticationStatus === "loading" ||
-                          isPaperLoginPending
-                        }
-                        onClick={() => openConnectModal && openConnectModal()}
-                        className="rounded-full whitespace-nowrap"
-                      >
-                        {authenticationStatus === "loading" ? (
-                          <Loading />
-                        ) : (
-                          "Connect"
-                        )}
-                      </Button>
+                      <SignInDialog />
                     </div>
                   );
                 }

--- a/src/components/paper/index.tsx
+++ b/src/components/paper/index.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import * as htmlToImage from "html-to-image";
 import { ArrowLeft, Download, Lock, LockOpen, PrinterIcon } from "lucide-react";
 import { useReactToPrint } from "react-to-print";
 import { toast } from "sonner";
+import { useConnectors } from "wagmi";
 import {
   EncryptedPaperWalletForm,
   type EncryptedPaperWalletFormTypes,
@@ -14,9 +16,13 @@ import {
   type PaperWalletCustomizationFormTypes,
 } from "~/components/forms/paper-wallet-customization-fields";
 import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Loading } from "~/components/loading";
+import { signInWithPaperWallet } from "~/lib/auth/paper-login";
 import { download } from "~/utils/download";
 import {
   PaperWallet,
+  toQRContent,
   type PaperWalletQRCodeContent,
 } from "~/utils/paper-wallet";
 import QRCard from "./qr-card";
@@ -28,7 +34,11 @@ export const CreatePaperWallet = () => {
       paperWalletCustomizationDefaultValues
     );
   const [type, setType] = useState<"encrypted" | "unencrypted">();
+  const [savedConfirmed, setSavedConfirmed] = useState(false);
+  const [isSigningIn, setIsSigningIn] = useState(false);
   const printRef = useRef(null);
+  const queryClient = useQueryClient();
+  const connectors = useConnectors();
 
   const handlePrint = useReactToPrint({
     contentRef: printRef,
@@ -107,6 +117,26 @@ export const CreatePaperWallet = () => {
   const handleBack = () => {
     setData(null);
     setType(undefined);
+    setSavedConfirmed(false);
+  };
+  const handleContinueToSignIn = async () => {
+    if (!data) return;
+    setIsSigningIn(true);
+    try {
+      new PaperWallet(toQRContent(data), sessionStorage);
+      await signInWithPaperWallet({ queryClient, connectors });
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Failed to sign in with paper wallet";
+      if (!message.toLowerCase().includes("cancel")) {
+        console.error("Failed to sign in with paper wallet", err);
+        toast.error(message);
+      }
+    } finally {
+      setIsSigningIn(false);
+    }
   };
   const backButtonJsx = (
     <Button variant="ghost" size="sm" onClick={handleBack} className="mr-2">
@@ -170,6 +200,29 @@ export const CreatePaperWallet = () => {
               >
                 <Download className="mr-2" />
                 Download
+              </Button>
+            </div>
+            <div className="border-t pt-4 mt-2 print:hidden space-y-4">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <Checkbox
+                  checked={savedConfirmed}
+                  onCheckedChange={(checked) =>
+                    setSavedConfirmed(checked === true)
+                  }
+                  className="mt-0.5"
+                  disabled={isSigningIn}
+                />
+                <span className="text-sm leading-snug select-none">
+                  I&apos;ve saved my QR code safely. I understand that losing it
+                  means losing access to my funds.
+                </span>
+              </label>
+              <Button
+                className="w-full"
+                disabled={!savedConfirmed || isSigningIn}
+                onClick={() => void handleContinueToSignIn()}
+              >
+                {isSigningIn ? <Loading /> : "Continue to Sign In"}
               </Button>
             </div>
           </div>

--- a/src/lib/auth/paper-login.ts
+++ b/src/lib/auth/paper-login.ts
@@ -1,0 +1,84 @@
+import { type QueryClient } from "@tanstack/react-query";
+import {
+  connect,
+  disconnect,
+  getAccount,
+  signMessage,
+  type Connector,
+} from "@wagmi/core";
+import { createSiweAdapter } from "~/config/siwe";
+import { config } from "~/config/wagmi.config.client";
+
+interface SignInWithPaperWalletParams {
+  queryClient: QueryClient;
+  connectors: readonly Connector[];
+  openConnectModal?: () => void;
+}
+
+export async function signInWithPaperWallet({
+  queryClient,
+  connectors,
+  openConnectModal,
+}: SignInWithPaperWalletParams): Promise<void> {
+  const paperConnector = connectors.find(
+    (connector) => connector.id === "paperConnector"
+  );
+
+  if (!paperConnector) {
+    openConnectModal?.();
+    return;
+  }
+
+  let accountAddress: `0x${string}` | undefined;
+  let chainId: number | undefined;
+  const activeAccount = getAccount(config);
+
+  if (activeAccount.status === "connected") {
+    if (activeAccount.connector?.id !== paperConnector.id) {
+      await disconnect(config);
+      const connection = await connect(config, {
+        connector: paperConnector,
+      });
+      const firstAccount = connection.accounts[0] as
+        | `0x${string}`
+        | { address: `0x${string}` }
+        | undefined;
+      accountAddress =
+        typeof firstAccount === "string"
+          ? firstAccount
+          : firstAccount?.address;
+      chainId = connection.chainId;
+    } else {
+      accountAddress = activeAccount.address;
+      chainId = activeAccount.chainId;
+    }
+  } else {
+    const connection = await connect(config, { connector: paperConnector });
+    const firstAccount = connection.accounts[0] as
+      | `0x${string}`
+      | { address: `0x${string}` }
+      | undefined;
+    accountAddress =
+      typeof firstAccount === "string" ? firstAccount : firstAccount?.address;
+    chainId = connection.chainId;
+  }
+
+  if (!accountAddress || !chainId) {
+    throw new Error("Paper Wallet connected but no account was found");
+  }
+
+  const siweAdapter = createSiweAdapter(queryClient);
+  const nonce = await siweAdapter.getNonce();
+  const message = siweAdapter.createMessage({
+    address: accountAddress,
+    chainId,
+    nonce,
+  });
+
+  const signature = await signMessage(config, { message });
+
+  const isVerified = await siweAdapter.verify({ message, signature });
+  if (!isVerified) {
+    throw new Error("Authentication failed");
+  }
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -119,9 +119,10 @@
     --muted: 210 17% 98%;
     --muted-foreground: 208 7% 46%;
 
-    /* Accent: Community gold - representing prosperity and growth */
-    --accent: 64 53% 42%;
-    --accent-foreground: 0 0% 100%;
+    /* Accent: subtle neutral used by shadcn primitives for hover/focus/active
+       highlights. The brand "community gold" lives on --button. */
+    --accent: 210 17% 94%;
+    --accent-foreground: 0 0% 10%;
 
     --destructive: 354 70% 54%;
     --destructive-foreground: 0 0% 100%;


### PR DESCRIPTION
## Summary
- Replaces the Login / Sign-up / Connect trio in the nav with one **Sign In** button that opens a responsive dialog (modal on desktop, bottom drawer on mobile) offering three options: connect an external wallet, sign in with an existing paper wallet, or create a new paper wallet.
- The new-paper-wallet flow now ends with an **"I've saved my QR code safely"** checkbox and a **Continue to Sign In** button that auto-saves the wallet to sessionStorage, runs SIWE, and lets the existing \`OnboardingGuard\` route first-time users into \`/onboarding\`.
- Extracts the paper-wallet SIWE flow into a reusable \`signInWithPaperWallet\` helper (\`src/lib/auth/paper-login.ts\`) so both the dialog and the create-wallet flow share one code path.

## Test plan
- [ ] Logged out: click **Sign In** → dialog shows all three options on desktop, bottom drawer on mobile.
- [ ] **Connect Wallet** → RainbowKit modal opens; external wallet (e.g. MetaMask / WalletConnect) signs SIWE and lands authenticated.
- [ ] **Sign in with Paper Wallet** (no wallet in sessionStorage) → dialog closes, paper-connector scan modal opens and is interactive (no overlay blocking); load a wallet, SIWE completes.
- [ ] **Create a Paper Wallet** → routes to \`/paper/create\`; generate encrypted *and* unencrypted; tick checkbox, click **Continue to Sign In**, and land at \`/onboarding\`.
- [ ] Returning user (\`onboarding_completed = true\`) signing in via any path lands at \`/wallet\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)