### PR TITLE
perf(pages): cache + hydrate voucher and pool routes to fix slow loads

### DIFF
--- a/src/app/(main)/pools/[address]/page.tsx
+++ b/src/app/(main)/pools/[address]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { getAddress } from "viem";
-import { getSwapPool } from "~/components/pools/contract-functions";
-import { publicClient } from "~/config/viem.config.server";
-import { caller } from "~/server/api/routers/_app";
+import {
+  getCachedSwapPool,
+  getPublicPoolMetadata,
+} from "~/server/api/public-fetchers";
 import { PoolClientPage } from "./pool-client-page";
+
+export const revalidate = 60;
 
 type Props = {
   params: Promise<{ address: string }>;
@@ -14,8 +17,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const pool_address = getAddress(params.address);
 
-  const poolDetails = await getSwapPool(publicClient, pool_address);
-  const poolData = await caller.pool.get(pool_address);
+  const [poolDetails, poolData] = await Promise.all([
+    getCachedSwapPool(pool_address),
+    getPublicPoolMetadata(pool_address),
+  ]);
 
   return {
     title: poolDetails?.name,
@@ -29,6 +34,22 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   };
 }
 
-export default function PoolPage() {
-  return <PoolClientPage />;
+export default async function PoolPage(props: {
+  params: Promise<{ address: string }>;
+}) {
+  const params = await props.params;
+  const pool_address = getAddress(params.address);
+
+  const [initialPool, initialMetadata] = await Promise.all([
+    getCachedSwapPool(pool_address),
+    getPublicPoolMetadata(pool_address),
+  ]);
+
+  return (
+    <PoolClientPage
+      address={pool_address}
+      initialPool={initialPool}
+      initialMetadata={initialMetadata}
+    />
+  );
 }

--- a/src/app/(main)/pools/[address]/pool-client-page.tsx
+++ b/src/app/(main)/pools/[address]/pool-client-page.tsx
@@ -2,7 +2,6 @@
 
 import { PhoneIcon, TagIcon } from "lucide-react";
 import Image from "next/image";
-import { useParams } from "next/navigation";
 import { toast } from "sonner";
 import { getAddress } from "viem";
 import Link from "next/link";
@@ -10,22 +9,36 @@ import Address from "~/components/address";
 import { EditableImageOverlay } from "~/components/editable-image-overlay";
 import { ContentContainer } from "~/components/layout/content-container";
 import { useSwapPool } from "~/components/pools/hooks";
+import { type SwapPool } from "~/components/pools/types";
 import { Badge } from "~/components/ui/badge";
 import { Skeleton } from "~/components/ui/skeleton";
 import { useAuth } from "~/hooks/use-auth";
 import { useIsContractOwner } from "~/hooks/use-is-owner";
-import { trpc } from "~/lib/trpc";
+import { type RouterOutputs, trpc } from "~/lib/trpc";
 import { celoscanUrl } from "~/utils/celo";
 import { formatPhoneInternational } from "~/utils/phone-number";
 import { hasPermission } from "~/utils/permissions";
 import { PoolButtons } from "./pool-buttons-client";
 import { PoolTabs } from "./pool-tabs";
 
-export function PoolClientPage() {
-  const { address } = useParams<{ address: string }>();
+type PoolMetadata = RouterOutputs["pool"]["get"];
+
+export function PoolClientPage({
+  address,
+  initialPool,
+  initialMetadata,
+}: {
+  address: `0x${string}`;
+  initialPool?: SwapPool;
+  initialMetadata?: PoolMetadata;
+}) {
   const pool_address = getAddress(address);
-  const { data: pool, isError: isPoolError, isLoading: isPoolLoading } = useSwapPool(pool_address);
-  const { data: metadata, isLoading: isMetadataLoading } = trpc.pool.get.useQuery(pool_address);
+  const { data: pool, isError: isPoolError, isLoading: isPoolLoading } =
+    useSwapPool(pool_address, initialPool);
+  const { data: metadata, isLoading: isMetadataLoading } =
+    trpc.pool.get.useQuery(pool_address, {
+      initialData: initialMetadata,
+    });
 
   const isOwner = useIsContractOwner(pool_address);
   const auth = useAuth();

--- a/src/app/(main)/vouchers/[address]/page.tsx
+++ b/src/app/(main)/vouchers/[address]/page.tsx
@@ -1,10 +1,12 @@
 import { type Metadata } from "next";
-import { redirect } from 'next/navigation';
+import { redirect } from "next/navigation";
 import { isAddress } from "viem";
 import VoucherPageClient from "~/components/voucher/voucher-page";
 import { publicClient } from "~/config/viem.config.server";
 import { getTokenDetails } from "~/server/api/models/token";
-import { caller } from "~/server/api/routers/_app";
+import { getPublicVoucher } from "~/server/api/public-fetchers";
+
+export const revalidate = 60;
 
 type Props = {
   params: Promise<{ address: string }>;
@@ -14,9 +16,7 @@ type Props = {
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const address = params.address;
-  const voucherData = await caller.voucher.byAddress({
-    voucherAddress: address,
-  });
+  const voucherData = await getPublicVoucher(address);
 
   return {
     title: voucherData?.voucher_name ?? "Unknown Voucher",
@@ -37,9 +37,16 @@ export default async function VouchersPage(props: {
   if (!address || !isAddress(address)) {
     return redirect("/vouchers");
   }
-  const voucher_details = await getTokenDetails(publicClient, {address});
+  const [voucher_details, voucher_metadata] = await Promise.all([
+    getTokenDetails(publicClient, { address }),
+    getPublicVoucher(address),
+  ]);
 
   return (
-    <VoucherPageClient address={address} details={voucher_details} />
+    <VoucherPageClient
+      address={address}
+      details={voucher_details}
+      initialVoucher={voucher_metadata}
+    />
   );
 }

--- a/src/components/voucher/voucher-page.tsx
+++ b/src/components/voucher/voucher-page.tsx
@@ -6,7 +6,7 @@ import { TabsContent } from "~/components/ui/tabs";
 import VoucherForm from "~/components/voucher/forms/voucher-form";
 import { VoucherHoldersTable } from "~/components/voucher/voucher-holders-table";
 import { useIsContractOwner } from "~/hooks/use-is-owner";
-import { trpc } from "~/lib/trpc";
+import { type RouterOutputs, trpc } from "~/lib/trpc";
 import { type VoucherDetails } from "../pools/contract-functions";
 import { ReportList } from "../reports/report-list";
 import { VoucherAnalyticsTab } from "./voucher-analytics-tab";
@@ -15,12 +15,16 @@ import { VoucherHomeTab } from "./voucher-home-tab";
 import { VoucherPoolsTab } from "./voucher-pools-tab";
 import { VoucherTabs } from "./voucher-tabs";
 
+type VoucherByAddress = RouterOutputs["voucher"]["byAddress"];
+
 const VoucherPage = ({
   address,
   details,
+  initialVoucher,
 }: {
   address: `0x${string}`;
   details: VoucherDetails;
+  initialVoucher?: VoucherByAddress;
 }) => {
   const voucher_address = address;
   const isOwner = useIsContractOwner(voucher_address);
@@ -29,6 +33,7 @@ const VoucherPage = ({
     {
       enabled: !!voucher_address,
       staleTime: 60_000,
+      initialData: initialVoucher,
     }
   );
   const [activeTab, setActiveTab] = useState("home");

--- a/src/server/api/public-fetchers.ts
+++ b/src/server/api/public-fetchers.ts
@@ -1,0 +1,59 @@
+import { cache } from "react";
+import { publicClient } from "~/config/viem.config.server";
+import { getSwapPool } from "~/components/pools/contract-functions";
+import { type SwapPool } from "~/components/pools/types";
+import { federatedDB, graphDB } from "~/server/db";
+import { cacheWithExpiry } from "~/utils/cache/cache";
+import { PoolModel } from "./models/pool";
+import { VoucherModel } from "./models/voucher";
+
+const VOUCHER_TTL = 60;
+const POOL_METADATA_TTL = 60;
+const SWAP_POOL_TTL = 30;
+
+export const getPublicVoucher = cache(async (address: string) => {
+  return cacheWithExpiry(
+    `public:voucher:${address.toLowerCase()}`,
+    VOUCHER_TTL,
+    () => {
+      const voucherModel = new VoucherModel({ graphDB, federatedDB });
+      return voucherModel
+        .findVoucherByAddress(address)
+        .then((v) => v ?? null);
+    }
+  );
+});
+
+export type PublicVoucher = Awaited<ReturnType<typeof getPublicVoucher>>;
+
+export const getPublicPoolMetadata = cache(
+  async (address: `0x${string}`) => {
+    return cacheWithExpiry(
+      `public:pool:${address.toLowerCase()}`,
+      POOL_METADATA_TTL,
+      () => {
+        const poolModel = new PoolModel({ graphDB, federatedDB });
+        return poolModel.get(address);
+      }
+    );
+  }
+);
+
+export type PublicPoolMetadata = Awaited<
+  ReturnType<typeof getPublicPoolMetadata>
+>;
+
+export const getCachedSwapPool = cache(
+  async (address: `0x${string}`): Promise<SwapPool | undefined> => {
+    try {
+      return await cacheWithExpiry(
+        `public:swap-pool:${address.toLowerCase()}`,
+        SWAP_POOL_TTL,
+        () => getSwapPool(publicClient, address)
+      );
+    } catch (error) {
+      console.error("getCachedSwapPool failed", { address, error });
+      return undefined;
+    }
+  }
+);


### PR DESCRIPTION
## Summary

The build-time cleanup in #441 was correct that the prerendered HTML wasn't being served, but it left `/vouchers/[address]` and `/pools/[address]` doing a cold dynamic render on every request — `generateMetadata` and the client both refetched the same heavy chain/DB data, and going through `caller.*` still triggered `auth()` cookie reads even on anonymous traffic.

- New `src/server/api/public-fetchers.ts` with React `cache()` + Redis-backed helpers (`getPublicVoucher`, `getPublicPoolMetadata`, `getCachedSwapPool`) so metadata + page body share one fetch and warm requests skip the chain multicall / DB roundtrip.
- Both pages drop `caller` for these helpers and add `export const revalidate = 60`, so the public render path no longer reads cookies and the route becomes ISR-eligible.
- Server now prefetches voucher/pool/SwapPool data and passes it down as `initialData` to `useQuery` / `useSwapPool`, eliminating the client-side double-fetch on mount.
- `getCachedSwapPool` swallows errors so invalid pool addresses still fall through to the existing client "Pool Not Found" UI instead of 500'ing.

## Test plan

- [ ] `pnpm check-types` passes
- [ ] `pnpm test` passes (434/434 locally)
- [ ] Load a voucher page anonymously → content paints immediately from server HTML, no client refetch of `voucher.byAddress`
- [ ] Load a pool page anonymously → hero + tabs render without a loading flash; connected wallet refetches per-account data as expected
- [ ] Invalid pool address still shows the "Pool Not Found" client state instead of an error page
- [ ] Vercel response headers show `x-vercel-cache: HIT` on a second request within the 60s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)