### PR TITLE
fix(swap): keep the From voucher selector populated

### DIFF
--- a/src/components/pools/forms/swap-form.tsx
+++ b/src/components/pools/forms/swap-form.tsx
@@ -357,9 +357,7 @@ export function SwapForm({ pool, onSuccess, initial }: SwapFormProps) {
     "amount",
   );
   const lastInitialToAddressRef = useRef<`0x${string}` | undefined>(undefined);
-  const lastInitialFromAddressRef = useRef<`0x${string}` | undefined>(
-    undefined,
-  );
+  const lastInitialFromAddressRef = useRef<string | undefined>(undefined);
   const lastInitialToAmountRef = useRef<string | undefined>(undefined);
   const [isInitializing, setIsInitializing] = useState(false);
   const [swapState, dispatch] = useReducer(swapReducer, { status: "form" });
@@ -393,20 +391,26 @@ export function SwapForm({ pool, onSuccess, initial }: SwapFormProps) {
   }, [initial?.toAddress, pool?.voucherDetails, setValue]);
 
   useEffect(() => {
-    if (!pool?.voucherDetails || !initial?.fromAddress) {
+    const fromAddress = initial?.fromAddress?.toLowerCase();
+    const toAddress = initial?.toAddress?.toLowerCase();
+    if (!pool?.voucherDetails || !fromAddress) {
       lastInitialFromAddressRef.current = undefined;
       return;
     }
-    if (lastInitialFromAddressRef.current === initial.fromAddress) return;
+    if (lastInitialFromAddressRef.current === fromAddress) return;
 
     const voucher = pool.voucherDetails.find(
-      (x) => x.address === initial.fromAddress,
+      (x) =>
+        x.address.toLowerCase() === fromAddress &&
+        x.address.toLowerCase() !== toAddress &&
+        (x.userBalance?.formattedNumber ?? 0) > MIN_SWAP_AMOUNT &&
+        (x.swapLimit?.formattedNumber ?? 0) > 0,
     );
     if (voucher) {
-      lastInitialFromAddressRef.current = initial.fromAddress;
+      lastInitialFromAddressRef.current = fromAddress;
       setValue("fromToken", voucher as z.infer<typeof zodPoolVoucher>);
     }
-  }, [initial?.fromAddress, pool?.voucherDetails, setValue]);
+  }, [initial?.fromAddress, initial?.toAddress, pool?.voucherDetails, setValue]);
 
   // Auto-select the from token that yields the most of the to token.
   // Re-runs when toToken or voucher balances change (e.g., after wallet connects).

--- a/src/components/pools/hooks.tsx
+++ b/src/components/pools/hooks.tsx
@@ -77,6 +77,12 @@ export const useSwapPool = (
       return getSwapPool(client, swapPoolAddress!, accountAddress);
     },
     initialData: initialData,
+    // SSR `initialData` is fetched without an account, so its userBalances are
+    // all 0. When a wallet is connected we need to refetch immediately with the
+    // account; without an `initialDataUpdatedAt` TanStack Query would treat the
+    // initial data as fresh for `staleTime` (60s) and skip the refetch, leaving
+    // every voucher with balance 0 and emptying the swap dropdown.
+    initialDataUpdatedAt: accountAddress ? 0 : undefined,
     enabled: !!swapPoolAddress && !!client,
     staleTime: 60_000,
   });


### PR DESCRIPTION
## Summary

The SwapForm's **From** voucher selector was rendering as either an empty chip or **"No vouchers available"** until React Query eventually refetched — the user's observed "sometimes it comes back." Two independent bugs were stacking.

## Bug 1 — `useSwapPool` blocks the account-aware refetch

`getCachedSwapPool` in `public-fetchers.ts` calls `getSwapPool(client, address)` server-side without an `accountAddress`, so the SSR `initialPool` has `userBalance = 0` for every voucher (`balanceOf(undefined)` no-ops in the multicall).

That payload is then handed to `useSwapPool` as `initialData`. Without `initialDataUpdatedAt`, React Query v5 considers the seed freshly fetched (`Date.now()`); combined with `staleTime: 60_000`, the new account-keyed `queryKey` is treated as fresh and **no refetch fires when the wallet connects** for up to 60 s.

Downstream, `filteredFromTokens` filters out every voucher with `userBalance.formattedNumber ≤ MIN_SWAP_AMOUNT (0.01)`. All zero → list is empty → dropdown renders the `emptyLabel` `"No vouchers available"`.

**Fix:** pass `initialDataUpdatedAt: accountAddress ? 0 : undefined` — when a wallet is present, mark the SSR seed stale so the query refetches immediately with the real account. When no wallet is connected, leave the seed fresh (refetching would just produce the same all-zero data).

## Bug 2 — `fromAddress` effect can stash an invisible voucher in `fromToken`

The `initial.fromAddress` effect in `swap-form.tsx`:

- did a **case-sensitive** `.find()` on `pool.voucherDetails`, while the sibling `toAddress` effect (and the rest of this codebase) lowercases both sides. The codebase's `USDT_TOKEN_ADDRESS` fallback is checksummed and voucher addresses come from on-chain multicalls — so a mismatch was common.
- didn't apply the same constraints as `filteredFromTokens`, so it could set `fromToken` to a voucher that the dropdown then excluded (same address as `toToken`, balance below `MIN_SWAP_AMOUNT`, or `swapLimit === 0`).

When either happened, `getFormFieldValue` in `SearchableSelect` looked up the selected value in `items` (the filtered list), failed to find it, returned `null`, and the chip rendered as the placeholder.

**Fix:** match case-insensitively and only set `fromToken` when the candidate passes the same filters as `filteredFromTokens`. If the user's `default_voucher` isn't viable for this pool, the existing `findBestFromToken` auto-pick takes over.

## Test plan

- [ ] Open a pool's Offers tab while logged out → "No vouchers available" still shown correctly (no balance because no account).
- [ ] Connect a wallet that has balance in at least one pool voucher → dropdown populates on first paint (no 60 s wait).
- [ ] Click a product where your `default_voucher` equals the product's voucher → From chip auto-fills with a different usable voucher instead of going blank.
- [ ] Click a product where your `default_voucher` is checksummed mixed-case in DB → From chip still resolves (case-insensitive match).
- [ ] Existing `pnpm check-types` and `pnpm lint` pass (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)